### PR TITLE
Add AtomicInt and AtomicReference utilities

### DIFF
--- a/Generator/Sources/NeedleFramework/Concurrency/AtomicReference.swift
+++ b/Generator/Sources/NeedleFramework/Concurrency/AtomicReference.swift
@@ -1,0 +1,100 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import libkern
+
+/// A concurrency utility class that ensures read and write-through memory behavior for the
+/// wrapped object. This is not a mutex utility. Concurrent access to this class is allowed.
+/// It only guarantees serial time events are consistent in the memory stack, thus preventing
+/// stale values. Since this class does not use mutex, this class is more efficient and has
+/// higher throughput than using a mutex lock.
+public class AtomicReference<ValueType> {
+
+    /// The value that guarantees atomic read and write-through memory behavior.
+    public var value: ValueType {
+        get {
+            // Create a memory barrier to ensure the entire memory stack is in sync so we
+            // can safely retrieve the value. This guarantees the initial value is in sync.
+            OSMemoryBarrier()
+            return wrappedValue
+        }
+        set {
+            OSMemoryBarrier()
+            wrappedValue = newValue
+            pointer.pointee = unsafePassUnretainedPointer(value: wrappedValue)
+        }
+    }
+
+    /// Initializer.
+    ///
+    /// - parameter initialValue: The initial value.
+    public init(initialValue: ValueType) {
+        wrappedValue = initialValue
+        pointer.pointee = unsafePassUnretainedPointer(value: wrappedValue)
+    }
+
+    /// Atomically sets the new value, if the current value's memory pointer equals the
+    /// expected value's memory pointer.
+    ///
+    /// - parameter expect: The expected value to compare against.
+    /// - parameter newValue: The new value to set to if the comparison succeeds.
+    /// - returns: true if the comparison succeeded and the value is set. false otherwise.
+    public func compareAndSet(expect: ValueType, newValue: ValueType) -> Bool {
+        let expectPointer = unsafePassUnretainedPointer(value: expect)
+        let newValuePointer = unsafePassUnretainedPointer(value: newValue)
+
+        if OSAtomicCompareAndSwapPtrBarrier(expectPointer, newValuePointer, pointer) {
+            // If pointer swap succeeded, a memory berrier is created, so we can safely write the new
+            // value.
+            wrappedValue = newValue
+            return true
+        } else {
+            return false
+        }
+    }
+
+    /// Atomically sets to the given new value and returns the old value.
+    ///
+    /// - parameter newValue: The new value to set to.
+    /// - returns: The old value.
+    public func getAndSet(newValue: ValueType) -> ValueType {
+        while true {
+            let oldValue = self.value
+            if compareAndSet(expect: oldValue, newValue: newValue) {
+                return oldValue
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private let pointer: UnsafeMutablePointer<UnsafeMutableRawPointer?> = UnsafeMutablePointer.allocate(capacity: 1)
+
+    private var wrappedValue: ValueType
+
+    private func unsafePassUnretainedPointer(value: ValueType) -> UnsafeMutableRawPointer {
+        return UnsafeMutableRawPointer(Unmanaged.passUnretained(value as AnyObject).toOpaque())
+    }
+
+    deinit {
+        #if swift(>=4.1)
+            pointer.deallocate()
+        #else
+            pointer.deallocate(capacity: 1)
+        #endif
+    }
+}

--- a/Generator/Tests/LinuxMain.swift
+++ b/Generator/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 
 XCTMain([
     testCase(AtomicIntTests.allTests),
+    testCase(AtomicReferenceTests.allTests),
     testCase(CountDownLatchTests.allTests),
 ])

--- a/Generator/Tests/NeedleFrameworkTests/Concurrency/AtomicIntTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Concurrency/AtomicIntTests.swift
@@ -1,5 +1,17 @@
 //
-//  Copyright © Uber Technologies, Inc. All rights reserved.
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import XCTest
@@ -13,6 +25,10 @@ class AtomicIntTests: XCTestCase {
         ("test_compareAndSet_verifySettingNewValue", test_compareAndSet_verifySettingNewValue),
         ("test_compareAndSet_withFalseExpectValue_verifyNotSettingNewValue", test_compareAndSet_withFalseExpectValue_verifyNotSettingNewValue),
         ("test_getAndSet_verifySettingNewValueReturningOldValue", test_getAndSet_verifySettingNewValueReturningOldValue),
+        ("test_incrementAndGet_verifyNewValue", test_incrementAndGet_verifyNewValue),
+        ("test_decrementAndGet_verifyNewValue", test_decrementAndGet_verifyNewValue),
+        ("test_getAndIncrement_verifyNewValue", test_getAndIncrement_verifyNewValue),
+        ("test_getAndDecrement_verifyNewValue", test_getAndDecrement_verifyNewValue),
     ]
 
     func test_init_verifyInitialValue() {
@@ -95,5 +111,85 @@ class AtomicIntTests: XCTestCase {
                 XCTAssertTrue(atomicInt.value == secondValue)
             }
         }
+    }
+
+    func test_incrementAndGet_verifyNewValue() {
+        let initialValue = 123
+        let atomicInt = AtomicInt(initialValue: initialValue)
+
+        XCTAssertTrue(atomicInt.value == initialValue)
+
+        DispatchQueue.concurrentPerform(iterations: 100000) { _ in
+            let newValue = atomicInt.incrementAndGet()
+            XCTAssertGreaterThan(newValue, initialValue)
+        }
+
+        XCTAssertEqual(atomicInt.value, 123+100000)
+
+        let newValue = atomicInt.incrementAndGet()
+
+        XCTAssertEqual(newValue, 123+100000+1)
+    }
+
+    func test_decrementAndGet_verifyNewValue() {
+        let initialValue = 123
+        let atomicInt = AtomicInt(initialValue: initialValue)
+
+        XCTAssertTrue(atomicInt.value == initialValue)
+
+        DispatchQueue.concurrentPerform(iterations: 100000) { _ in
+            let newValue = atomicInt.decrementAndGet()
+            XCTAssertLessThan(newValue, initialValue)
+        }
+
+        XCTAssertEqual(atomicInt.value, 123-100000)
+
+        let newValue = atomicInt.decrementAndGet()
+
+        XCTAssertEqual(newValue, 123-100000-1)
+    }
+
+    func test_getAndIncrement_verifyNewValue() {
+        let initialValue = 123
+        let atomicInt = AtomicInt(initialValue: initialValue)
+
+        XCTAssertTrue(atomicInt.value == initialValue)
+
+        DispatchQueue.concurrentPerform(iterations: 100000) { _ in
+            let oldValue = atomicInt.getAndIncrement()
+            XCTAssertGreaterThanOrEqual(oldValue, initialValue)
+        }
+
+        XCTAssertEqual(atomicInt.value, 123+100000)
+
+        let oldValue = atomicInt.getAndIncrement()
+
+        XCTAssertEqual(oldValue, 123+100000)
+
+        let newValue = atomicInt.value
+
+        XCTAssertEqual(newValue, 123+100000+1)
+    }
+
+    func test_getAndDecrement_verifyNewValue() {
+        let initialValue = 123
+        let atomicInt = AtomicInt(initialValue: initialValue)
+
+        XCTAssertTrue(atomicInt.value == initialValue)
+
+        DispatchQueue.concurrentPerform(iterations: 100000) { _ in
+            let oldValue = atomicInt.getAndDecrement()
+            XCTAssertLessThanOrEqual(oldValue, initialValue)
+        }
+
+        XCTAssertEqual(atomicInt.value, 123-100000)
+
+        let oldValue = atomicInt.getAndDecrement()
+
+        XCTAssertEqual(oldValue, 123-100000)
+
+        let newValue = atomicInt.value
+
+        XCTAssertEqual(newValue, 123-100000-1)
     }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Concurrency/AtomicReferenceTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Concurrency/AtomicReferenceTests.swift
@@ -1,0 +1,154 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import NeedleFramework
+
+class AtomicReferenceTests: XCTestCase {
+
+    static var allTests = [
+        ("test_init_verifyInitialValue", test_init_verifyInitialValue),
+        ("test_initGetSet_verifySetToNewValue", test_initGetSet_verifySetToNewValue),
+        ("test_compareAndSet_verifySettingNewValue", test_compareAndSet_verifySettingNewValue),
+        ("test_compareAndSet_withFalseExpectValue_verifyNotSettingNewValue", test_compareAndSet_withFalseExpectValue_verifyNotSettingNewValue),
+        ("test_compareAndSet_withNil_verifySettingNewValue", test_compareAndSet_withNil_verifySettingNewValue),
+        ("test_getAndSet_verifySettingNewValueReturningOldValue", test_getAndSet_verifySettingNewValueReturningOldValue),
+        ("test_compareAndSet_initialNilThenResetToNil_verifySuccess", test_compareAndSet_initialNilThenResetToNil_verifySuccess),
+    ]
+
+    func test_init_verifyInitialValue() {
+        let initialValue = NSObject()
+        let atomicRef = AtomicReference<NSObject>(initialValue: initialValue)
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            XCTAssertTrue(atomicRef.value === initialValue)
+        }
+    }
+
+    func test_initGetSet_verifySetToNewValue() {
+        let initialValue = NSObject()
+        let atomicRef = AtomicReference<NSObject>(initialValue: initialValue)
+
+        XCTAssertTrue(atomicRef.value === initialValue)
+
+        let secondValue = NSObject()
+
+        DispatchQueue.concurrentPerform(iterations: 1) { _ in
+            atomicRef.value = secondValue
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                XCTAssertFalse(atomicRef.value === initialValue)
+                XCTAssertTrue(atomicRef.value === secondValue)
+            }
+        }
+    }
+
+    func test_compareAndSet_verifySettingNewValue() {
+        let initialValue = NSObject()
+        let atomicRef = AtomicReference<NSObject>(initialValue: initialValue)
+
+        XCTAssertTrue(atomicRef.value === initialValue)
+
+        let secondValue = NSObject()
+        DispatchQueue.concurrentPerform(iterations: 1) { _ in
+            let result = atomicRef.compareAndSet(expect: initialValue, newValue: secondValue)
+            XCTAssertTrue(result)
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                XCTAssertFalse(atomicRef.value === initialValue)
+                XCTAssertTrue(atomicRef.value === secondValue)
+            }
+        }
+    }
+
+    func test_compareAndSet_withFalseExpectValue_verifyNotSettingNewValue() {
+        let initialValue = NSObject()
+        let atomicRef = AtomicReference<NSObject>(initialValue: initialValue)
+
+        XCTAssertTrue(atomicRef.value === initialValue)
+
+        let secondValue = NSObject()
+        DispatchQueue.concurrentPerform(iterations: 1) { _ in
+            let result = atomicRef.compareAndSet(expect: NSObject(), newValue: secondValue)
+            XCTAssertFalse(result)
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                XCTAssertTrue(atomicRef.value === initialValue)
+                XCTAssertFalse(atomicRef.value === secondValue)
+            }
+        }
+    }
+
+    func test_compareAndSet_withNil_verifySettingNewValue() {
+        let atomicRef = AtomicReference<String?>(initialValue: nil)
+
+        XCTAssertNil(atomicRef.value)
+
+        let secondValue = "What?!"
+        DispatchQueue.concurrentPerform(iterations: 1) { _ in
+            let result = atomicRef.compareAndSet(expect: nil, newValue: secondValue)
+            XCTAssertTrue(result)
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                XCTAssertNotNil(atomicRef.value)
+                XCTAssertEqual(atomicRef.value, secondValue)
+            }
+        }
+    }
+
+    func test_getAndSet_verifySettingNewValueReturningOldValue() {
+        let initialValue = NSObject()
+        let atomicRef = AtomicReference<NSObject>(initialValue: initialValue)
+
+        XCTAssertTrue(atomicRef.value === initialValue)
+
+        let secondValue = NSObject()
+        DispatchQueue.concurrentPerform(iterations: 1) { _ in
+            let result = atomicRef.getAndSet(newValue: secondValue)
+            XCTAssertTrue(result === initialValue)
+            XCTAssertTrue(atomicRef.value === secondValue)
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                XCTAssertFalse(atomicRef.value === initialValue)
+                XCTAssertTrue(atomicRef.value === secondValue)
+            }
+        }
+    }
+
+    func test_compareAndSet_initialNilThenResetToNil_verifySuccess() {
+        let atomicRef = AtomicReference<NSObject?>(initialValue: nil)
+        let firstValue = NSObject()
+        var result = atomicRef.compareAndSet(expect: nil, newValue: firstValue)
+        XCTAssertTrue(result)
+        XCTAssertTrue(atomicRef.value === firstValue)
+
+        atomicRef.value = nil
+        XCTAssertNil(atomicRef.value)
+
+        let secondValue = NSObject()
+        result = atomicRef.compareAndSet(expect: nil, newValue: secondValue)
+        XCTAssertTrue(result)
+        XCTAssertTrue(atomicRef.value === secondValue)
+
+        let thirdValue = NSObject()
+        atomicRef.value = thirdValue
+        XCTAssertTrue(atomicRef.value === thirdValue)
+
+        result = atomicRef.compareAndSet(expect: thirdValue, newValue: nil)
+        XCTAssertTrue(result)
+        XCTAssertNil(atomicRef.value)
+    }
+}

--- a/Generator/Tests/NeedleFrameworkTests/Concurrency/CountDownLatchTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Concurrency/CountDownLatchTests.swift
@@ -1,5 +1,17 @@
 //
-//  Copyright © Uber Technologies, Inc. All rights reserved.
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import XCTest


### PR DESCRIPTION
These utilities will be used to provide locking free synchronization for the concurrent parsing and generating processes.