### PR TITLE
Skip suffixes if provided, better directory scan

### DIFF
--- a/Generator/Sources/NeedleFramework/FileParser.swift
+++ b/Generator/Sources/NeedleFramework/FileParser.swift
@@ -35,6 +35,28 @@ public struct Component {
         self.children = []
         self.parents = []
     }
+
+    public func fakeGenerateForTiming() -> String {
+
+        let middle = members.map { (name, kind) in
+            return """
+                var \(name) : \(kind) = {
+                    return dependeny.\(name)
+                }
+
+
+            """
+        }.joined()
+
+        let result = """
+        class \(self.name)Provider {
+        \(middle)}
+
+        
+        """
+
+        return result
+    }
 }
 
 public struct Dependency {


### PR DESCRIPTION
- Recursive directory scan now calls a closure
- You can interleave work, or collect in an array