### PR TITLE
Allow `SequenceExecutor` to return a result at the end of sequence

### DIFF
--- a/Generator/Sources/NeedleFramework/FileParser.swift
+++ b/Generator/Sources/NeedleFramework/FileParser.swift
@@ -17,53 +17,53 @@
 import Foundation
 import SourceKittenFramework
 
-struct Component {
-    let name: String
-    let dependency: String
-    var members: [(String, String)]
-    let filePath: String
-    let offsetInFile: Int
-    var children: [Component]
-    var parents: [Component]
-
-    init(name: String, dependency: String, members: [(String, String)], filePath: String) {
-        self.name = name
-        self.dependency = dependency
-        self.members = members
-        self.filePath = filePath
-        self.offsetInFile = 0
-        self.children = []
-        self.parents = []
-    }
-
-    func fakeGenerateForTiming() -> String {
-
-        let middle = members.map { (name, kind) in
-            return """
-                var \(name) : \(kind) = {
-                    return dependeny.\(name)
-                }
-
-
-            """
-        }.joined()
-
-        let result = """
-        class \(self.name)Provider {
-        \(middle)}
-
-        
-        """
-
-        return result
-    }
-}
+//struct Component {
+//    let name: String
+//    let dependency: String
+//    var members: [(String, String)]
+//    let filePath: String
+//    let offsetInFile: Int
+//    var children: [Component]
+//    var parents: [Component]
+//
+//    init(name: String, dependency: String, members: [(String, String)], filePath: String) {
+//        self.name = name
+//        self.dependency = dependency
+//        self.members = members
+//        self.filePath = filePath
+//        self.offsetInFile = 0
+//        self.children = []
+//        self.parents = []
+//    }
+//
+//    func fakeGenerateForTiming() -> String {
+//
+//        let middle = members.map { (name, kind) in
+//            return """
+//                var \(name) : \(kind) = {
+//                    return dependeny.\(name)
+//                }
+//
+//
+//            """
+//        }.joined()
+//
+//        let result = """
+//        class \(self.name)Provider {
+//        \(middle)}
+//
+//
+//        """
+//
+//        return result
+//    }
+//}
 
 struct Dependency {
-    var name: String
-    var members: [(String, String)]
-    let filePath: String
-    let offsetInFile: Int
+//    var name: String
+//    var members: [(String, String)]
+//    let filePath: String
+//    let offsetInFile: Int
 }
 
 class FileParser {
@@ -76,65 +76,65 @@ class FileParser {
         self.path = path
     }
 
-    private func parseClass(_ structure: [String: SourceKitRepresentable], filePath: String) -> Component? {
-        var dep: String?
-        for inheritedType in structure.inheritedTypes {
-            if let match = componentsExpression.firstMatch(in: inheritedType),
-                let range = Range(match.range(at: 1), in: inheritedType) {
-                dep = String(inheritedType[range])
-            }
-        }
-        guard let dependency = dep else { return nil }
-
-        let vars: [(String, String)] = structure.substructure.compactMap { item in
-            if let name = item.name, let typeName = item.typeName, let kind = item.kind {
-                if SwiftDeclarationKind(rawValue: kind) == .varInstance {
-                    return (name, typeName)
-                }
-            }
-            return nil
-        }
-        return Component(name: structure.name!, dependency: dependency, members: vars, filePath: filePath)
-    }
-
-    private func parseProtocol(_ structure: [String: SourceKitRepresentable], filePath: String) -> Dependency? {
-        let vars: [(String, String)] = structure.substructure.compactMap { item in
-            if let name = item.name, let typeName = item.typeName, let kind = item.kind, SwiftDeclarationKind(rawValue: kind) == .varInstance {
-                return (name, typeName)
-            } else {
-                return nil
-            }
-        }
-        return Dependency(name: structure.name!, members: vars, filePath: filePath, offsetInFile: 0)
-    }
+//    private func parseClass(_ structure: [String: SourceKitRepresentable], filePath: String) -> Component? {
+//        var dep: String?
+//        for inheritedType in structure.inheritedTypes {
+//            if let match = componentsExpression.firstMatch(in: inheritedType),
+//                let range = Range(match.range(at: 1), in: inheritedType) {
+//                dep = String(inheritedType[range])
+//            }
+//        }
+//        guard let dependency = dep else { return nil }
+//
+//        let vars: [(String, String)] = structure.substructure.compactMap { item in
+//            if let name = item.name, let typeName = item.typeName, let kind = item.kind {
+//                if SwiftDeclarationKind(rawValue: kind) == .varInstance {
+//                    return (name, typeName)
+//                }
+//            }
+//            return nil
+//        }
+//        return Component(name: structure.name!, dependency: dependency, members: vars, filePath: filePath)
+//    }
+//
+//    private func parseProtocol(_ structure: [String: SourceKitRepresentable], filePath: String) -> Dependency? {
+//        let vars: [(String, String)] = structure.substructure.compactMap { item in
+//            if let name = item.name, let typeName = item.typeName, let kind = item.kind, SwiftDeclarationKind(rawValue: kind) == .varInstance {
+//                return (name, typeName)
+//            } else {
+//                return nil
+//            }
+//        }
+//        return Dependency(name: structure.name!, members: vars, filePath: filePath, offsetInFile: 0)
+//    }
 
     func parse() -> ([Component], [Dependency])? {
-        let result = try? Structure(file: file)
-
-        if let result = result {
-            let substructure = result.dictionary.substructure
-
-            // Find component subclasses
-            let components: [Component] = substructure.compactMap { structure in
-                if let kind = structure.kind, SwiftDeclarationKind(rawValue: kind) == .class {
-                    return parseClass(structure, filePath: path)
-                } else {
-                    return nil
-                }
-            }
-            let dependencyNames = components.map { $0.dependency }
-
-            // Scan for dependency protocols using the list generated above
-            let dependencies: [Dependency] = substructure.compactMap { structure in
-                if let name = structure.name, let kind = structure.kind, SwiftDeclarationKind(rawValue: kind) == .protocol {
-                    if dependencyNames.contains(name) {
-                        return parseProtocol(structure, filePath: path)
-                    }
-                }
-                return nil
-            }
-            return (components, dependencies)
-        }
+//        let result = try? Structure(file: file)
+//
+//        if let result = result {
+//            let substructure = result.dictionary.substructure
+//
+//            // Find component subclasses
+//            let components: [Component] = substructure.compactMap { structure in
+//                if let kind = structure.kind, SwiftDeclarationKind(rawValue: kind) == .class {
+//                    return parseClass(structure, filePath: path)
+//                } else {
+//                    return nil
+//                }
+//            }
+//            let dependencyNames = components.map { $0.dependency }
+//
+//            // Scan for dependency protocols using the list generated above
+//            let dependencies: [Dependency] = substructure.compactMap { structure in
+//                if let name = structure.name, let kind = structure.kind, SwiftDeclarationKind(rawValue: kind) == .protocol {
+//                    if dependencyNames.contains(name) {
+//                        return parseProtocol(structure, filePath: path)
+//                    }
+//                }
+//                return nil
+//            }
+//            return (components, dependencies)
+//        }
 
         return nil
     }

--- a/Generator/Sources/NeedleFramework/Models/Component.swift
+++ b/Generator/Sources/NeedleFramework/Models/Component.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A data model representing a dependency graph scope declared by a NeedleFoundation
+/// `Component` subclass.
+struct Component {
+    /// The name of the component.
+    let name: String
+    /// A list of properties this component instantiates, thereby provides.
+    let providedProperties: [Property]
+    /// A list of properties this component requires, aka dependencies.
+    let dependencies: [Property]
+    /// The list of names of child components this component instantiates.
+    let childComponentNames: [String]
+}

--- a/Generator/Sources/NeedleFramework/Models/Property.swift
+++ b/Generator/Sources/NeedleFramework/Models/Property.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A data model representing a dependency property that is either provided by a
+/// `Component` or required by one.
+struct Property {
+    /// The variable name.
+    let name: String
+    /// The property type `String`.
+    let type: String
+}

--- a/Generator/Sources/NeedleFramework/Parsing/ASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/ASTParserTask.swift
@@ -18,15 +18,23 @@ import Foundation
 import SourceKittenFramework
 
 /// A task that parses Swift AST into in-memory dependency graph data models.
-class ASTParserTask: SequencedTask {
+class ASTParserTask: SequencedTask<[Component]> {
 
+    /// The AST structure of the file to parse.
     let structure: Structure
 
+    /// Initializer.
+    ///
+    /// - parameter structure: The AST structure of the file to parse.
     init(structure: Structure) {
         self.structure = structure
     }
 
-    func execute() -> SequencedTask? {
-        return nil
+    /// Execute the task and returns the in-memory dependency graph data models.
+    /// This is the last task in the sequence.
+    ///
+    /// - returns: `nil`.
+    override func execute() -> ExecutionResult<[Component]> {
+        return .endOfSequence([])
     }
 }

--- a/Generator/Sources/NeedleFramework/Parsing/ASTProducerTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/ASTProducerTask.swift
@@ -19,7 +19,7 @@ import SourceKittenFramework
 
 /// A task that parses a Swift source content and produces Swift AST that can then be
 /// parsed into the dependnecy graph.
-class ASTProducerTask: SequencedTask {
+class ASTProducerTask: SequencedTask<[Component]> {
 
     /// The source URL.
     let sourceUrl: URL
@@ -35,11 +35,14 @@ class ASTProducerTask: SequencedTask {
         self.sourceContent = sourceContent
     }
 
-    func execute() -> SequencedTask? {
+    /// Execute the task and returns `ASTParserTask` if parsing file into AST succeeded.
+    ///
+    /// - returns: `ASTParserTask` if parsing file into AST succeeded.
+    override func execute() -> ExecutionResult<[Component]> {
         let file = File(contents: sourceContent)
         do {
             let structure = try Structure(file: file)
-            return ASTParserTask(structure: structure)
+            return .continueSequence(ASTParserTask(structure: structure))
         } catch {
             fatalError("Failed to parse AST for source at \(sourceUrl)")
         }

--- a/Generator/Sources/NeedleFramework/ProviderGenerator.swift
+++ b/Generator/Sources/NeedleFramework/ProviderGenerator.swift
@@ -86,12 +86,12 @@ public class ProviderGenerator {
         }
         print("files scanned:", total.value)
 
-        let result = allComponents.map { component in
-            component.fakeGenerateForTiming()
-        }.joined()
-
-        let outPath = "/tmp/Providers.swift"
-        try? result.write(toFile: outPath, atomically: true, encoding: .utf8)
+//        let result = allComponents.map { component in
+//            component.fakeGenerateForTiming()
+//        }.joined()
+//
+//        let outPath = "/tmp/Providers.swift"
+//        try? result.write(toFile: outPath, atomically: true, encoding: .utf8)
     }
 
     public init() {}

--- a/Generator/Sources/NeedleFramework/Sequence/SequencedTask.swift
+++ b/Generator/Sources/NeedleFramework/Sequence/SequencedTask.swift
@@ -16,16 +16,24 @@
 
 import Foundation
 
-/// A task that after execution can optionally return another task to form a sequence
-/// of tasks to be executed.
-public protocol SequencedTask: AnyObject {
+/// The execution result of a single `SequencedTask`.
+enum ExecutionResult<SequenceResultType> {
+    /// The execution of the sequence should continue with another task.
+    case continueSequence(SequencedTask<SequenceResultType>)
+    /// The end of the entire task sequence with produced result.
+    case endOfSequence(SequenceResultType)
+}
 
-    /// Execute this task and the returned task if there is one.
+/// A task that after execution can optionally return another task to form a sequence
+/// of tasks to be executed, or an end result produced by the entire sequence.
+// This cannot be a protocol, since `ExecutionResult` references this as a type.
+// Protocols with associatedType cannot be directly used as types.
+class SequencedTask<SequenceResultType> {
+
+    /// Execute this task.
     ///
-    /// - returns: An optional task to be executed after this task is executed. If a
-    /// new task is returned, this task and the returned one effectively forms a task
-    /// sequence to be executed like an assembly line. If `nil` is returned, this
-    /// task effectively becomes the terminating task, marking the completion of the
-    /// entire task sequence.
-    func execute() -> SequencedTask?
+    /// - returns: The execution result of this task.
+    func execute() -> ExecutionResult<SequenceResultType> {
+        fatalError("execute not yet implemented.")
+    }
 }

--- a/Generator/Tests/NeedleFrameworkTests/FileParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/FileParserTests.swift
@@ -37,11 +37,11 @@ class FileParserTests: XCTestCase {
             if let (comps, deps) = parser.parse() {
                 print(comps, deps)
                 XCTAssert(comps.count == 2)
-                XCTAssert(comps[0].members.count == 3)
-                XCTAssert(comps[1].members.count == 2)
-                XCTAssert(deps.count == 2)
-                XCTAssert(deps[0].members.count == 3)
-                XCTAssert(deps[1].members.count == 2)
+//                XCTAssert(comps[0].members.count == 3)
+//                XCTAssert(comps[1].members.count == 2)
+//                XCTAssert(deps.count == 2)
+//                XCTAssert(deps[0].members.count == 3)
+//                XCTAssert(deps[1].members.count == 2)
             } else {
                 XCTFail("Expected a non-nil response from the parser")
             }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ASTProducerTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ASTProducerTaskTests.swift
@@ -26,8 +26,14 @@ class ASTProducerTaskTests: AbstractParsingTests {
         let astContent = try! Structure(file: File(contents: sourceContent))
 
         let task = ASTProducerTask(sourceUrl: sourceUrl, sourceContent: sourceContent)
-        let nextTask = task.execute() as! ASTParserTask
+        let result = task.execute()
 
-        XCTAssertEqual(nextTask.structure, astContent)
+        switch result {
+        case .continueSequence(let nextTask):
+            let parserTask = nextTask as! ASTParserTask
+            XCTAssertEqual(parserTask.structure, astContent)
+        default:
+            XCTFail()
+        }
     }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/FileFilterTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/FileFilterTaskTests.swift
@@ -23,8 +23,14 @@ class FileFilterTaskTests: AbstractParsingTests {
         let fileUrl = fixtureUrl(for: "NonSwift.json")
         let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [])
 
-        let nextTask = task.execute()
-        XCTAssertNil(nextTask)
+        let result = task.execute()
+
+        switch result {
+        case .continueSequence(_):
+            XCTFail()
+        case .endOfSequence(let components):
+            XCTAssertTrue(components.isEmpty)
+        }
     }
 
     func test_execute_excludedSuffix_verifyFilter() {
@@ -32,32 +38,56 @@ class FileFilterTaskTests: AbstractParsingTests {
         let content = try! String(contentsOf: fileUrl)
         let excludeSuffixTask = FileFilterTask(url: fileUrl, exclusionSuffixes: ["Sample"])
 
-        var nextTask = excludeSuffixTask.execute()
-        XCTAssertNil(nextTask)
+        var result = excludeSuffixTask.execute()
+
+        switch result {
+        case .continueSequence(_):
+            XCTFail()
+        case .endOfSequence(let components):
+            XCTAssertTrue(components.isEmpty)
+        }
 
         let includeSuffixTask = FileFilterTask(url: fileUrl, exclusionSuffixes: [])
 
-        nextTask = includeSuffixTask.execute()
-        let producerTask = nextTask as! ASTProducerTask
-        XCTAssertNotNil(nextTask)
-        XCTAssertEqual(producerTask.sourceUrl, fileUrl)
-        XCTAssertEqual(producerTask.sourceContent, content)
+        result = includeSuffixTask.execute()
+
+        switch result {
+        case .continueSequence(let nextTask):
+            let producerTask = nextTask as! ASTProducerTask
+            XCTAssertNotNil(nextTask)
+            XCTAssertEqual(producerTask.sourceUrl, fileUrl)
+            XCTAssertEqual(producerTask.sourceContent, content)
+        case .endOfSequence(_):
+            XCTFail()
+        }
     }
 
     func test_execute_nonNeedleComponent_verifyFilter() {
         let fixturesURL = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Fixtures/NonNeedleComponent.swift")
         let task = FileFilterTask(url: fixturesURL, exclusionSuffixes: [])
 
-        let nextTask = task.execute()
-        XCTAssertNil(nextTask)
+        let result = task.execute()
+
+        switch result {
+        case .continueSequence(_):
+            XCTFail()
+        case .endOfSequence(let components):
+            XCTAssertTrue(components.isEmpty)
+        }
     }
 
     func test_execute_nonInheritanceComponent_verifyFilter() {
         let fixturesURL = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Fixtures/NonInheritanceComponent.swift")
         let task = FileFilterTask(url: fixturesURL, exclusionSuffixes: [])
 
-        let nextTask = task.execute()
-        XCTAssertNil(nextTask)
+        let result = task.execute()
+
+        switch result {
+        case .continueSequence(_):
+            XCTFail()
+        case .endOfSequence(let components):
+            XCTAssertTrue(components.isEmpty)
+        }
     }
 
     func test_execute_actualComponent_verifyNextTask() {
@@ -65,10 +95,16 @@ class FileFilterTaskTests: AbstractParsingTests {
         let content = try! String(contentsOf: fileUrl)
         let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [])
 
-        let nextTask = task.execute()
-        let producerTask = nextTask as! ASTProducerTask
-        XCTAssertNotNil(nextTask)
-        XCTAssertEqual(producerTask.sourceUrl, fileUrl)
-        XCTAssertEqual(producerTask.sourceContent, content)
+        let result = task.execute()
+
+        switch result {
+        case .continueSequence(let nextTask):
+            let producerTask = nextTask as! ASTProducerTask
+            XCTAssertNotNil(nextTask)
+            XCTAssertEqual(producerTask.sourceUrl, fileUrl)
+            XCTAssertEqual(producerTask.sourceContent, content)
+        case .endOfSequence(_):
+            XCTFail()
+        }
     }
 }


### PR DESCRIPTION
This allows each individual sequence to have its own lock inside the `SequenceExecutionHandle`, thereby avoiding any contention. The aggregator that consumes the results of all sequences do not have to add any locking. This is more efficient than using a global data structure to store all the results from all the sequences. Since each sequence is running on multiple threads, a single data structure would be heavily contented by all the sequences.