### PR TITLE
Add support for multi-level branching

### DIFF
--- a/Foundation/Sources/NeedleFoundation/Bootstrap.swift
+++ b/Foundation/Sources/NeedleFoundation/Bootstrap.swift
@@ -30,7 +30,10 @@ public class EmptyDependencyProvider: EmptyDependency {
 
 /// An empty class that can be used as the bootstrap component, the parent component of the
 /// root component in the dependency graph.
-public class BootstrapComponent {
+public class BootstrapComponent: Scope {
+
+    /// The path to reach this scope on the dependnecy graph.
+    public let path: String = "^"
 
     /// Initializer.
     public init() {}

--- a/Foundation/Tests/NeedleFoundationTests/ComponentTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/ComponentTests.swift
@@ -22,14 +22,22 @@ class ComponentTests: XCTestCase {
     static var allTests = [
         ("test_shared_veirfySingleInstance", test_shared_veirfySingleInstance),
     ]
-    
+
+    override func setUp() {
+        super.setUp()
+
+        let path = "^->NeedleFoundationTests.TestComponent"
+        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) {_ in
+            return EmptyDependencyProvider()
+        }
+    }
+
     func test_shared_veirfySingleInstance() {
-        // TODO: Enable test once generation is implemented.
-//        let component = TestComponent(parent: BootstrapComponent())
-//        XCTAssert(component.share === component.share, "Should have returned same shared object")
-//
-//        XCTAssertTrue(component.share2 === component.share2)
-//        XCTAssertFalse(component.share === component.share2)
+        let component = TestComponent(parent: BootstrapComponent())
+        XCTAssert(component.share === component.share, "Should have returned same shared object")
+
+        XCTAssertTrue(component.share2 === component.share2)
+        XCTAssertFalse(component.share === component.share2)
     }
 }
 

--- a/Foundation/Tests/NeedleFoundationTests/DependencyProviderRegistryTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/DependencyProviderRegistryTests.swift
@@ -26,14 +26,17 @@ class DependencyProviderRegistryTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "NeedleFoundationTests.MockAppComponent", withParentComponentName: "NeedleFoundation.BootstrapComponent") {_ in
+        let path = "^->NeedleFoundationTests.MockAppComponent"
+        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) {_ in
             return EmptyDependencyProvider()
         }
     }
 
     func test_registerProviderFactory_verifyRetrievingProvider_verifyDependencyReference() {
         let expectedProvider = MockRootDependencyProvider()
-        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "NeedleFoundationTests.MockRootComponent", withParentComponentName: "NeedleFoundationTests.MockAppComponent") { (component: ComponentType) -> AnyObject in
+
+        let path = "^->NeedleFoundationTests.MockAppComponent->NeedleFoundationTests.MockRootComponent"
+        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) { (component: ComponentType) -> AnyObject in
             return expectedProvider
         }
 


### PR DESCRIPTION
Add a `path` property that is computed at runtime as scopes get instantiated. This tracks the entire runtime "true" path that reached the component. This allows the `Component` to retrieve the `DependencyProvider` uniquely for the path, therefore supporting multi-level branching in the dependency graph.

Fixes #41