### PR TITLE
Remove module name from component path

### DIFF
--- a/Foundation/Sources/NeedleFoundation/Component.swift
+++ b/Foundation/Sources/NeedleFoundation/Component.swift
@@ -47,7 +47,10 @@ open class Component<DependencyType>: ComponentType {
     // Use `lazy var` to avoid computing the path repeatedly. Internally, this is always
     // accessed with the `__DependencyProviderRegistry`'s lock acquired.
     public lazy var path: String = {
-        return parent.path + "->\(self)"
+        let fullyQualifiedSelfName = String(describing: self)
+        let parts = fullyQualifiedSelfName.components(separatedBy: ".")
+        let name = parts.last ?? fullyQualifiedSelfName
+        return parent.path + "->\(name)"
     }()
 
     /// The dependency of this component.

--- a/Foundation/Tests/NeedleFoundationTests/ComponentTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/ComponentTests.swift
@@ -26,7 +26,7 @@ class ComponentTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let path = "^->NeedleFoundationTests.TestComponent"
+        let path = "^->TestComponent"
         __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) {_ in
             return EmptyDependencyProvider()
         }

--- a/Foundation/Tests/NeedleFoundationTests/DependencyProviderRegistryTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/DependencyProviderRegistryTests.swift
@@ -26,7 +26,7 @@ class DependencyProviderRegistryTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let path = "^->NeedleFoundationTests.MockAppComponent"
+        let path = "^->MockAppComponent"
         __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) {_ in
             return EmptyDependencyProvider()
         }
@@ -35,7 +35,7 @@ class DependencyProviderRegistryTests: XCTestCase {
     func test_registerProviderFactory_verifyRetrievingProvider_verifyDependencyReference() {
         let expectedProvider = MockRootDependencyProvider()
 
-        let path = "^->NeedleFoundationTests.MockAppComponent->NeedleFoundationTests.MockRootComponent"
+        let path = "^->MockAppComponent->MockRootComponent"
         __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) { (component: ComponentType) -> AnyObject in
             return expectedProvider
         }


### PR DESCRIPTION
Since we currently do not support module name for collision resolution, we should just remove it from the path.