### PR TITLE
Ignore private and fileprivate properties

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/ASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/ASTParserTask.swift
@@ -103,6 +103,12 @@ private extension Dictionary where Key: ExpressibleByStringLiteral {
 
     var properties: [Property] {
         return filterSubstructure(by: "source.lang.swift.decl.var.instance")
+            .filter { (item: [String: SourceKitRepresentable]) -> Bool in
+                if let accessibility = item["key.accessibility"] as? String {
+                    return accessibility != "source.lang.swift.accessibility.private" && accessibility != "source.lang.swift.accessibility.fileprivate"
+                }
+                fatalError("Property missing accessibility identifier.")
+            }
             .map { (item: [String: SourceKitRepresentable]) -> Property in
                 if let variableName = item["key.name"] as? String {
                     if let typeName = item["key.typename"] as? String {

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -34,6 +34,14 @@ class My2Component: Component<My2Dependency> {
             Book()
         }
     }
+
+    private var banana: Banana {
+        return Banana()
+    }
+
+    fileprivate var apple: Apple {
+        return Apple()
+    }
 }
 
 protocol My2Dependency: Dependency {

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ASTParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ASTParserTaskTests.swift
@@ -61,7 +61,7 @@ class ASTParserTaskTests: AbstractParsingTests {
             let my2Component = node.components.first { (component: Component) -> Bool in
                 component.name == "My2Component"
             }!
-            XCTAssertEqual(my2Component.expressionCallTypeNames, ["shared", "Book"])
+            XCTAssertEqual(my2Component.expressionCallTypeNames, ["shared", "Banana", "Apple", "Book"])
             XCTAssertEqual(my2Component.name, "My2Component")
             XCTAssertEqual(my2Component.dependencyProtocolName, "My2Dependency")
             XCTAssertEqual(my2Component.properties.count, 1)


### PR DESCRIPTION
These properties are limited to the residing scope, and therefore should not be visible on the DI graph. Fixes #57