### PR TITLE
Remove the Scope protocol.

### DIFF
--- a/Foundation/NeedleFoundation.xcodeproj/project.pbxproj
+++ b/Foundation/NeedleFoundation.xcodeproj/project.pbxproj
@@ -31,14 +31,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4139094820A0EDA500A26FF5 /* PBXContainerItemProxy */ = {
+		F7BA78CE20AE232D00079AF9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "NeedleFoundation::NeedleFoundation";
 			remoteInfo = NeedleFoundation;
 		};
-		4139094920A0EDA500A26FF5 /* PBXContainerItemProxy */ = {
+		F7BA78CF20AE232D00079AF9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
@@ -106,8 +106,8 @@
 		OBJ_17 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				"NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */,
 				"NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */,
+				"NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -254,12 +254,12 @@
 		OBJ_39 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */;
-			targetProxy = 4139094920A0EDA500A26FF5 /* PBXContainerItemProxy */;
+			targetProxy = F7BA78CF20AE232D00079AF9 /* PBXContainerItemProxy */;
 		};
 		OBJ_49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "NeedleFoundation::NeedleFoundation" /* NeedleFoundation */;
-			targetProxy = 4139094820A0EDA500A26FF5 /* PBXContainerItemProxy */;
+			targetProxy = F7BA78CE20AE232D00079AF9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -336,7 +336,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.9.3.0.9E145.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -345,7 +345,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.9.3.0.9E145.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;

--- a/Foundation/Sources/NeedleFoundation/Bootstrap.swift
+++ b/Foundation/Sources/NeedleFoundation/Bootstrap.swift
@@ -30,10 +30,15 @@ public class EmptyDependencyProvider: EmptyDependency {
 
 /// An empty class that can be used as the bootstrap component, the parent component of the
 /// root component in the dependency graph.
-public class BootstrapComponent: Scope {
+public class BootstrapComponent: ComponentType {
 
     /// The path to reach this scope on the dependnecy graph.
     public let path: String = "^"
+
+    /// This component does not have a parent
+    public var parent: ComponentType {
+        fatalError("BootstrapComponent does not have a parent, do not use this property.")
+    }
 
     /// Initializer.
     public init() {}

--- a/Foundation/Sources/NeedleFoundation/Component.swift
+++ b/Foundation/Sources/NeedleFoundation/Component.swift
@@ -16,22 +16,16 @@
 
 import Foundation
 
-/// A protocol defining a scope on the dependency graph. A scope only requires a path to
-/// reach the scope.
-public protocol Scope: AnyObject {
-
-    /// The path to reach this scope on the dependnecy graph.
-    var path: String { get }
-}
-
 /// The base protocol of a component. Application code should inherit from the `Component`
 /// base class, instead of using this protocol directly.
-public protocol ComponentType: Scope {
+public protocol ComponentType: AnyObject {
+    /// The path to reach this component on the dependnecy graph.
+    var path: String { get }
 
     /// The parent of this component.
     // This property cannot be of `ComponentType`, since the root of the dependency graph
     // must have a parent that does not have a parent.
-    var parent: Scope { get }
+    var parent: ComponentType { get }
 }
 
 /// The base implementation of a dependency injection component. A subclass defines a unique
@@ -41,7 +35,7 @@ public protocol ComponentType: Scope {
 open class Component<DependencyType>: ComponentType {
 
     /// The parent of this component.
-    public let parent: Scope
+    public let parent: ComponentType
 
     /// The path to reach this scope on the dependnecy graph.
     // Use `lazy var` to avoid computing the path repeatedly. Internally, this is always
@@ -62,7 +56,7 @@ open class Component<DependencyType>: ComponentType {
     /// Initializer.
     ///
     /// - parameter parent: The parent component of this component.
-    public init(parent: Scope) {
+    public init(parent: ComponentType) {
         self.parent = parent
         dependency = createDependencyProvider()
     }


### PR DESCRIPTION
- This will allow us to pass a ComponentType into the constructor of the DependencyProviders
- This in turn will let us traverse to the parents, with the ".parent" property.