### PR TITLE
Merge NeedleFoundationExtension into NeedleFoundation

### DIFF
--- a/Foundation/NeedleFoundation.xcodeproj/project.pbxproj
+++ b/Foundation/NeedleFoundation.xcodeproj/project.pbxproj
@@ -6,21 +6,12 @@
 	objectVersion = 46;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		"NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" /* NeedleFoundationPackageTests */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_36 /* Build configuration list for PBXAggregateTarget "NeedleFoundationPackageTests" */;
-			buildPhases = (
-			);
-			dependencies = (
-				OBJ_39 /* PBXTargetDependency */,
-			);
-			name = NeedleFoundationPackageTests;
-			productName = NeedleFoundationPackageTests;
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
+		41F0681520D45AD100FD67C7 /* PluginizedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F0681020D45AD100FD67C7 /* PluginizedComponent.swift */; };
+		41F0681620D45AD100FD67C7 /* PluginExtensionProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F0681220D45AD100FD67C7 /* PluginExtensionProviderRegistry.swift */; };
+		41F0681720D45AD100FD67C7 /* NonCoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F0681320D45AD100FD67C7 /* NonCoreComponent.swift */; };
+		41F0681820D45AD100FD67C7 /* PluginizedLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F0681420D45AD100FD67C7 /* PluginizedLifecycle.swift */; };
+		41F0681B20D45B1300FD67C7 /* PluginizedComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F0681A20D45B1300FD67C7 /* PluginizedComponentTests.swift */; };
 		OBJ_25 /* Bootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Bootstrap.swift */; };
 		OBJ_26 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Component.swift */; };
 		OBJ_27 /* DependencyProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* DependencyProviderRegistry.swift */; };
@@ -37,16 +28,14 @@
 			remoteGlobalIDString = "NeedleFoundation::NeedleFoundation";
 			remoteInfo = NeedleFoundation;
 		};
-		41B6EE0D20B766FF00BFF8F8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTests";
-			remoteInfo = NeedleFoundationTests;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		41F0681020D45AD100FD67C7 /* PluginizedComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginizedComponent.swift; sourceTree = "<group>"; };
+		41F0681220D45AD100FD67C7 /* PluginExtensionProviderRegistry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginExtensionProviderRegistry.swift; sourceTree = "<group>"; };
+		41F0681320D45AD100FD67C7 /* NonCoreComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonCoreComponent.swift; sourceTree = "<group>"; };
+		41F0681420D45AD100FD67C7 /* PluginizedLifecycle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginizedLifecycle.swift; sourceTree = "<group>"; };
+		41F0681A20D45B1300FD67C7 /* PluginizedComponentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginizedComponentTests.swift; sourceTree = "<group>"; };
 		"NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NeedleFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = NeedleFoundationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
@@ -75,6 +64,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		41F0680F20D45ABA00FD67C7 /* Pluginized */ = {
+			isa = PBXGroup;
+			children = (
+				41F0681120D45AD100FD67C7 /* Internal */,
+				41F0681320D45AD100FD67C7 /* NonCoreComponent.swift */,
+				41F0681020D45AD100FD67C7 /* PluginizedComponent.swift */,
+				41F0681420D45AD100FD67C7 /* PluginizedLifecycle.swift */,
+			);
+			path = Pluginized;
+			sourceTree = "<group>";
+		};
+		41F0681120D45AD100FD67C7 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				41F0681220D45AD100FD67C7 /* PluginExtensionProviderRegistry.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		41F0681920D45B0300FD67C7 /* Pluginized */ = {
+			isa = PBXGroup;
+			children = (
+				41F0681A20D45B1300FD67C7 /* PluginizedComponentTests.swift */,
+			);
+			path = Pluginized;
+			sourceTree = "<group>";
+		};
 		OBJ_11 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +110,7 @@
 		OBJ_14 /* NeedleFoundationTests */ = {
 			isa = PBXGroup;
 			children = (
+				41F0681920D45B0300FD67C7 /* Pluginized */,
 				OBJ_15 /* ComponentTests.swift */,
 				OBJ_16 /* DependencyProviderRegistryTests.swift */,
 			);
@@ -130,6 +147,7 @@
 		OBJ_8 /* NeedleFoundation */ = {
 			isa = PBXGroup;
 			children = (
+				41F0680F20D45ABA00FD67C7 /* Pluginized */,
 				OBJ_9 /* Bootstrap.swift */,
 				OBJ_10 /* Component.swift */,
 				OBJ_11 /* Internal */,
@@ -174,20 +192,6 @@
 			productReference = "NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		"NeedleFoundation::SwiftPMPackageDescription" /* NeedleFoundationPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_30 /* Build configuration list for PBXNativeTarget "NeedleFoundationPackageDescription" */;
-			buildPhases = (
-				OBJ_33 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = NeedleFoundationPackageDescription;
-			productName = NeedleFoundationPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -209,8 +213,6 @@
 			projectRoot = "";
 			targets = (
 				"NeedleFoundation::NeedleFoundation" /* NeedleFoundation */,
-				"NeedleFoundation::SwiftPMPackageDescription" /* NeedleFoundationPackageDescription */,
-				"NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" /* NeedleFoundationPackageTests */,
 				"NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */,
 			);
 		};
@@ -221,16 +223,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				41F0681620D45AD100FD67C7 /* PluginExtensionProviderRegistry.swift in Sources */,
 				OBJ_25 /* Bootstrap.swift in Sources */,
+				41F0681820D45AD100FD67C7 /* PluginizedLifecycle.swift in Sources */,
 				OBJ_26 /* Component.swift in Sources */,
+				41F0681520D45AD100FD67C7 /* PluginizedComponent.swift in Sources */,
+				41F0681720D45AD100FD67C7 /* NonCoreComponent.swift in Sources */,
 				OBJ_27 /* DependencyProviderRegistry.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_33 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -240,17 +239,13 @@
 			files = (
 				OBJ_45 /* ComponentTests.swift in Sources */,
 				OBJ_46 /* DependencyProviderRegistryTests.swift in Sources */,
+				41F0681B20D45B1300FD67C7 /* PluginizedComponentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_39 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */;
-			targetProxy = 41B6EE0D20B766FF00BFF8F8 /* PBXContainerItemProxy */;
-		};
 		OBJ_49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "NeedleFoundation::NeedleFoundation" /* NeedleFoundation */;
@@ -328,36 +323,6 @@
 			};
 			name = Debug;
 		};
-		OBJ_31 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.9.3.0.9E145.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Debug;
-		};
-		OBJ_32 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.9.3.0.9E145.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
-		OBJ_37 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		OBJ_38 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
 		OBJ_4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -434,24 +399,6 @@
 			buildConfigurations = (
 				OBJ_22 /* Debug */,
 				OBJ_23 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_30 /* Build configuration list for PBXNativeTarget "NeedleFoundationPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_31 /* Debug */,
-				OBJ_32 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_36 /* Build configuration list for PBXAggregateTarget "NeedleFoundationPackageTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_37 /* Debug */,
-				OBJ_38 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Foundation/Sources/NeedleFoundation/Pluginized/Internal/PluginExtensionProviderRegistry.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/Internal/PluginExtensionProviderRegistry.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR COITIONS OF ANY KI, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Needle internal registry of plugin extension providers.
+/// - note: This class is only needed until Swift supports extensions
+/// overriding methods. This is an internal class to the Needle dependency
+/// injection framework. Application code should never use this class.
+// TODO: Remove this once Swift supports extension overriding methods.
+// Once that happens, we can declare an `open createPluginExtensionProvider`
+// method in the base pluginized component class. Generate extensions to
+// all the pluginized component subclasses that override the method to
+// instantiate the dependnecy providers.
+public class __PluginExtensionProviderRegistry {
+
+    /// The singleton instance.
+    public static let instance = __PluginExtensionProviderRegistry()
+
+    /// Register the given factory closure with given key.
+    ///
+    /// - note: This method is thread-safe.
+    /// - parameter componentPath: The dependency graph path of the component
+    /// the provider is for.
+    /// - parameter pluginExtensionProviderFactory: The closure that takes in
+    /// a component to be injected and returns a provider instance that conforms
+    /// to the component's plugin extensions protocol.
+    public func registerPluginExtensionProviderFactory(`for` componentPath: String, _ pluginExtensionProviderFactory: @escaping (PluginizedComponentType) -> AnyObject) {
+        // Lock on `providerFactories` access.
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
+        providerFactories[componentPath.hashValue] = pluginExtensionProviderFactory
+    }
+
+    func pluginExtensionProvider(`for` component: PluginizedComponentType) -> AnyObject {
+        // Lock on `providerFactories` access.
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
+        if let factory = providerFactories[component.path.hashValue] {
+            return factory(component)
+        } else {
+            fatalError("Missing plugin extension provider factory for \(component.path)")
+        }
+    }
+
+    private let lock = NSRecursiveLock()
+    private var providerFactories = [Int: (PluginizedComponentType) -> AnyObject]()
+
+    private init() {}
+}

--- a/Foundation/Sources/NeedleFoundation/Pluginized/NonCoreComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/NonCoreComponent.swift
@@ -1,0 +1,74 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The base protocol for a non-core component defining its lifecycle to
+/// support scope activation and deactivation.
+///
+/// - note: A separate protocol is used to allow `PluginizableComponent`
+/// to delcare a non-core component generic without having to specify the
+/// dependency protocol nested generics.
+public protocol NonCoreComponentType: AnyObject {
+    /// Initializer.
+    ///
+    /// - parameter parent: The parent component of this component.
+    init(parent: ComponentType)
+
+    /// Indicate the corresponding core scope has become active, thereby
+    /// activating this non-core component as well.
+    ///
+    /// - note: This method is automatically invoked when the non-core component
+    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// Otherwise, this method must be explicitly invoked.
+    func scopeDidBecomeActive()
+
+    /// Indicate the corresponding core scope has become inactive, thereby
+    /// deactivating this non-core component as well.
+    ///
+    /// - note: This method is automatically invoked when the non-core component
+    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// Otherwise, this method must be explicitly invoked.
+    func scopeDidBecomeInactive()
+}
+
+/// The base non-core component class. All non-core components should inherit
+/// from this class.
+open class NonCoreComponent<DependencyType>: Component<DependencyType>, NonCoreComponentType {
+
+    /// Initializer.
+    ///
+    /// - parameter parent: The parent component of this component.
+    public required override init(parent: ComponentType) {
+        super.init(parent: parent)
+    }
+
+    /// Indicate the corresponding core scope has become active, thereby
+    /// activating this non-core component as well.
+    ///
+    /// - note: This method is automatically invoked when the non-core component
+    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// Otherwise, this method must be explicitly invoked.
+    open func scopeDidBecomeActive() {}
+
+    /// Indicate the corresponding core scope has become inactive, thereby
+    /// deactivating this non-core component as well.
+    ///
+    /// - note: This method is automatically invoked when the non-core component
+    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// Otherwise, this method must be explicitly invoked.
+    open func scopeDidBecomeInactive() {}
+}

--- a/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
@@ -1,0 +1,133 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR COITIONS OF ANY KI, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The base protocol for a component that's pluginized. It defines the
+/// pairing methods to manage its and its corresponding non-core component's
+/// lifecycle.
+///
+/// - note: A separate protocol is used to allow `PluginizedBuilder` to
+/// delcare a pluginized component generic without having to specify the
+/// nested generics.
+public protocol PluginizedComponentType: ComponentType {
+    /// Bind the plugnizable component to the router's lifecycle. This ensures
+    /// the associated non-core component is released when the given router scope
+    /// is deallocated.
+    ///
+    /// - note: This method must be invoked when using a `PluginizedComponent`,
+    /// to avoid memory leak of the component and the non-core component.
+    /// - note: This method is required, because the non-core component reference
+    /// cannot be made weak. If the non-core component is weak, it is deallocated
+    /// before the plugin points are created lazily.
+    /// - parameter lifecycle: The `PluginizedLifecycle` to bind to.
+    func bind(to lifecycle: PluginizedLifecycle)
+
+    /// Signal the corresponding `PluginizedBuilder` is about to deinit.
+    /// This allows the pluginized component to release its corresponding
+    /// non-core component, breaking the retain cycle between it and its
+    /// non-core component.
+    func builderWillDeinit()
+}
+
+/// The base pluginized component class. All core components that involve
+/// plugins should inherit from this class.
+open class PluginizedComponent<DependencyType, PluginExtensionType, NonCoreComponent: NonCoreComponentType>: Component<DependencyType>, PluginizedComponentType {
+
+    /// The plugin extension granting access to plugin points provided by
+    /// the corresponding non-core component of this component.
+    public private(set) var pluginExtension: PluginExtensionType!
+
+    /// The type-erased non-core component instance. Subclasses should not
+    /// directly access this property.
+    public var nonCoreComponent: AnyObject {
+        guard let value = releasableNonCoreComponent else {
+            fatalError("Attempt to access non-core component of \(self) after it has been released.")
+        }
+        return value
+    }
+
+    /// Initializer.
+    ///
+    /// - parameter parent: The parent component of this component.
+    public override init(parent: ComponentType) {
+        super.init(parent: parent)
+        releasableNonCoreComponent = NonCoreComponent(parent: self)
+        pluginExtension = createPluginExtensionProvider()
+    }
+
+    /// Bind the plugnizable component to the router's lifecycle. This ensures
+    /// the associated non-core component is released when the given router scope
+    /// is deallocated.
+    ///
+    /// - note: This method must be invoked when using a `PluginizedComponent`,
+    /// to avoid memory leak of the component and the non-core component.
+    /// - note: This method is required, because the non-core component reference
+    /// cannot be made weak. If the non-core component is weak, it is deallocated
+    /// before the plugin points are created lazily.
+    /// - parameter lifecycle: The `PluginizedLifecycle` to bind to.
+    public func bind(to lifecycle: PluginizedLifecycle) {
+        guard lifecycleObserverDisposable == nil else {
+            return
+        }
+
+        lifecycleObserverDisposable = lifecycle.observe { (isActive: Bool) in
+            if isActive {
+                self.releasableNonCoreComponent?.scopeDidBecomeActive()
+            } else {
+                self.releasableNonCoreComponent?.scopeDidBecomeInactive()
+            }
+        }
+    }
+
+    /// Signal the corresponding `PluginizedBuilder` is about to deinit.
+    /// This allows the pluginized component to release its corresponding
+    /// non-core component, breaking the retain cycle between it and its
+    /// non-core component.
+    public func builderWillDeinit() {
+        // Only release the non-core component after the builder, which should be the owner
+        // reference to the component is released. Cannot release the non-core component when
+        // the bound router is detached. The builder may build another instance of the RIB
+        // with the same instance of this component again. In that case, this component will
+        // try to access its released non-core component to recreate plugin points.
+        self.releasableNonCoreComponent = nil
+    }
+
+    // MARK: - Private
+
+    private var lifecycleObserverDisposable: ObserverDisposable?
+
+    // Must retain the non-core component so it doesn't get deallocated before it's used
+    // to pull plugin points, since the plugin points are created lazily.
+    private var releasableNonCoreComponent: NonCoreComponentType?
+
+    // TODO: Replace this with an `open` method, once Swift supports extension overriding methods.
+    private func createPluginExtensionProvider() -> PluginExtensionType {
+        let provider = __PluginExtensionProviderRegistry.instance.pluginExtensionProvider(for: self)
+        if let pluginExtension = provider as? PluginExtensionType {
+            return pluginExtension
+        } else {
+            fatalError("Plugin extension provider factory for \(self) returned incorrect type. Should be of type \(String(describing: PluginExtensionType.self)). Actual type is \(String(describing: provider))")
+        }
+    }
+
+    deinit {
+        guard let lifecycleObserverDisposable = lifecycleObserverDisposable else {
+            fatalError("\(self) should be bound to its corresponding lifecyle to avoid memory leaks.")
+        }
+        lifecycleObserverDisposable.dispose()
+    }
+}

--- a/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedLifecycle.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedLifecycle.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The object that allows an observer to be disposed, thereby ending the
+/// observation.
+public protocol ObserverDisposable {
+
+    /// Dispose the observation.
+    func dispose()
+}
+
+/// The lifecycle of a pluginized scope.
+public protocol PluginizedLifecycle {
+
+    /// Observe the lifecycle with given observer.
+    ///
+    /// - parameter observer: The observer closure to invoke when the lifecycle
+    /// changes.
+    /// - returns: The disposable object that can end the observation.
+    func observe(_ observer: @escaping (Bool) -> Void) -> ObserverDisposable
+}

--- a/Foundation/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
@@ -1,0 +1,149 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import NeedleFoundation
+
+class PluginizedComponentTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->MockPluginizedComponent") { component in
+            return EmptyDependencyProvider(component: component)
+        }
+
+        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->MockPluginizedComponent->MockNonCoreComponent") { component in
+            return EmptyDependencyProvider(component: component)
+        }
+
+        __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: "^->MockPluginizedComponent") { pluginizedComponent in
+            return EmptyPluginExtensionsProvider()
+        }
+    }
+
+    func test_nonCoreComponent_pluginExtensions_verifyTypes() {
+        let mockPluginizedComponent = MockPluginizedComponent()
+
+        XCTAssertTrue(mockPluginizedComponent.nonCoreComponent is MockNonCoreComponent)
+        XCTAssertTrue(mockPluginizedComponent.pluginExtension is EmptyPluginExtensionsProvider)
+    }
+
+    func test_bindTo_verifyNonCoreComponentLifecycle() {
+        let mockPluginizedComponent = MockPluginizedComponent()
+        let mockDisposable = MockObserverDisposable()
+        let mockLifecycle = MockPluginizedLifecycle(disposable: mockDisposable)
+        let noncoreComponent: MockNonCoreComponent? = mockPluginizedComponent.nonCoreComponent as? MockNonCoreComponent
+        mockPluginizedComponent.bind(to: mockLifecycle)
+
+        XCTAssertEqual(noncoreComponent!.scopeDidBecomeActiveCallCount, 0)
+        XCTAssertEqual(noncoreComponent!.scopeDidBecomeInactiveCallCount, 0)
+
+        mockLifecycle.observer!(true)
+
+        XCTAssertEqual(noncoreComponent!.scopeDidBecomeActiveCallCount, 1)
+        XCTAssertEqual(noncoreComponent!.scopeDidBecomeInactiveCallCount, 0)
+
+        mockLifecycle.observer!(false)
+
+        XCTAssertEqual(noncoreComponent!.scopeDidBecomeActiveCallCount, 1)
+        XCTAssertEqual(noncoreComponent!.scopeDidBecomeInactiveCallCount, 1)
+    }
+
+    func test_builderWillDeinit_verifyReleasingNonCoreComponent() {
+        let mockPluginizedComponent = MockPluginizedComponent()
+        var noncoreComponent: MockNonCoreComponent? = mockPluginizedComponent.nonCoreComponent as? MockNonCoreComponent
+        var noncoreDeinitCallCount = 0
+        noncoreComponent!.deinitHandler = {
+            noncoreDeinitCallCount += 1
+        }
+        let mockDisposable = MockObserverDisposable()
+        let mockLifecycle = MockPluginizedLifecycle(disposable: mockDisposable)
+        mockPluginizedComponent.bind(to: mockLifecycle)
+
+        XCTAssertNotNil(noncoreComponent)
+        XCTAssertEqual(noncoreDeinitCallCount, 0)
+
+        noncoreComponent = nil
+
+        XCTAssertNil(noncoreComponent)
+        XCTAssertEqual(noncoreDeinitCallCount, 0)
+
+        mockPluginizedComponent.builderWillDeinit()
+
+        XCTAssertNil(noncoreComponent)
+        XCTAssertEqual(noncoreDeinitCallCount, 1)
+
+        XCTAssertNil(noncoreComponent)
+        XCTAssertEqual(noncoreDeinitCallCount, 1)
+    }
+}
+
+class MockNonCoreComponent: NonCoreComponent<EmptyDependency> {
+
+    var deinitHandler: (() -> Void)?
+
+    var scopeDidBecomeActiveCallCount = 0
+    var scopeDidBecomeInactiveCallCount = 0
+
+    override func scopeDidBecomeActive() {
+        scopeDidBecomeActiveCallCount += 1
+    }
+
+    override func scopeDidBecomeInactive() {
+        scopeDidBecomeInactiveCallCount += 1
+    }
+
+    deinit {
+        deinitHandler?()
+    }
+}
+
+protocol EmptyPluginExtensions {}
+
+class EmptyPluginExtensionsProvider: EmptyPluginExtensions {}
+
+class MockPluginizedComponent: PluginizedComponent<EmptyDependency, EmptyPluginExtensions, MockNonCoreComponent> {
+
+    init() {
+        super.init(parent: BootstrapComponent())
+    }
+}
+
+class MockPluginizedLifecycle: PluginizedLifecycle {
+
+    let disposable: ObserverDisposable
+
+    init(disposable: ObserverDisposable) {
+        self.disposable = disposable
+    }
+
+    var observer: ((Bool) -> Void)?
+
+    func observe(_ observer: @escaping (Bool) -> Void) -> ObserverDisposable {
+        self.observer = observer
+        return disposable
+    }
+}
+
+class MockObserverDisposable: ObserverDisposable {
+
+    var disposeCallCount = 0
+
+    func dispose() {
+        disposeCallCount += 1
+    }
+}


### PR DESCRIPTION
As part of the effort to simplify the dependency tree of Needle, NeedleFoundationExtension base classes are merged into NeedleFoundation.

Also removed unnecessary targets and schemes.