### PR TITLE
Add PluginExtension parsing

### DIFF
--- a/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
@@ -43,6 +43,9 @@ public protocol PluginizedComponentType: ComponentType {
     func builderWillDeinit()
 }
 
+/// The base protocol of a plugin extension, enabling Needle's parsing process.
+public protocol PluginExtension: AnyObject {}
+
 /// The base pluginized component class. All core components that involve
 /// plugins should inherit from this class.
 open class PluginizedComponent<DependencyType, PluginExtensionType, NonCoreComponent: NonCoreComponentType>: Component<DependencyType>, PluginizedComponentType {

--- a/Generator/Sources/NeedleFramework/Models/Pluginized/PluginExtension.swift
+++ b/Generator/Sources/NeedleFramework/Models/Pluginized/PluginExtension.swift
@@ -16,16 +16,13 @@
 
 import Foundation
 
-/// The special empty dependency data model.
-let emptyDependency = Dependency(name: "EmptyDependency", properties: [])
-
-/// A data model representing a dependency protocol of a NeedleFoundation
-/// `Component`.
-// This is separate from the `Component` data model, since a component's
-// dependency protocol may be declared in a separate file.
-struct Dependency: Equatable {
-    /// The name of the dependency protocol.
+/// A data model representing a plugin extension protocol of a NeedleFoundation
+/// `PluginizedComponent`.
+// This is separate from the `PluginizedComponent` data model, since its
+// plugin extension protocol may be declared in a separate file.
+struct PluginExtension: Equatable {
+    /// The name of the plugin extension protocol.
     let name: String
-    /// The list of dependency properties.
+    /// The list of properties.
     let properties: [Property]
 }

--- a/Generator/Sources/NeedleFramework/Models/Pluginized/PluginizableComponent.swift
+++ b/Generator/Sources/NeedleFramework/Models/Pluginized/PluginizableComponent.swift
@@ -24,21 +24,18 @@ import Foundation
 class PluginizableASTComponent {
     /// The actual data of this component.
     let data: ASTComponent
-    /// The type name of the plugin extension if this component is a
-    /// pluginized component.
-    let pluginExtensionType: String?
-    /// The type name of the non-core component if this component is a
-    /// pluginized component.
-    let nonCoreComponentType: String?
+    /// The type name of the plugin extension.
+    let pluginExtensionType: String
+    /// The type name of the non-core component.
+    let nonCoreComponentType: String
 
     /// Initializer.
     ///
     /// - parameter data: The actual data of this component.
-    /// - parameter pluginExtensionType: The type name of the plugin extension
-    /// if this component is a pluginized component.
+    /// - parameter pluginExtensionType: The type name of the plugin extension.
     /// - parameter nonCoreComponentType: The type name of the non-core
-    /// component if this component is a pluginized component.
-    init(data: ASTComponent, pluginExtensionType: String? = nil, nonCoreComponentType: String? = nil) {
+    /// component.
+    init(data: ASTComponent, pluginExtensionType: String, nonCoreComponentType: String) {
         self.data = data
         self.pluginExtensionType = pluginExtensionType
         self.nonCoreComponentType = nonCoreComponentType
@@ -50,6 +47,6 @@ class PluginizableASTComponent {
 struct PluginizableComponent {
     /// The actual data of this component.
     let data: Component
-    /// The non-core component if this component is a pluginized component.
-    let nonCoreComponent: Component?
+    /// The non-core component.
+    let nonCoreComponent: Component
 }

--- a/Generator/Sources/NeedleFramework/Models/Pluginized/PluginizableDependencyGraphNode.swift
+++ b/Generator/Sources/NeedleFramework/Models/Pluginized/PluginizableDependencyGraphNode.swift
@@ -20,7 +20,13 @@ import Foundation
 /// The components may be pluginized components or regular ones.
 struct PluginizableDependencyGraphNode {
     /// The list of pluginiable components in this node.
-    let components: [PluginizableASTComponent]
+    let pluginiableComponents: [PluginizableASTComponent]
+    /// The list of non-core components in this node.
+    let nonCoreComponents: [ASTComponent]
+    /// The list of plugin extensions in this node.
+    let pluginExtensions: [PluginExtension]
+    /// The list of regular components in this node.
+    let components: [ASTComponent]
     /// The list of dependencies in this node.
     let dependencies: [Dependency]
     /// The list of import statements including the `import` keyword.

--- a/Generator/Sources/NeedleFramework/Parsing/FileFilters/ContentFilter.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/FileFilters/ContentFilter.swift
@@ -31,13 +31,21 @@ class ContentFilter: FileFilter {
     /// - returns: `true` if the
     func filter() -> Bool {
         // Use simple string matching first since it's more performant.
-        if !content.contains("Component") {
+        if !content.contains("Component") && !content.contains("Dependency") {
             return false
         }
 
         // Match actual component inheritance using Regex.
         let containsComponentInheritance = (Regex(": *Component *<").firstMatch(in: content) != nil)
-        return containsComponentInheritance
+        if containsComponentInheritance {
+            return true
+        }
+        let containsDependencyInheritance = (Regex(": *Dependency").firstMatch(in: content) != nil)
+        if containsDependencyInheritance {
+            return true
+        }
+
+        return false
     }
 
     // MARK: - Private

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/FileFilters/PluginizedContentFilter.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/FileFilters/PluginizedContentFilter.swift
@@ -41,7 +41,7 @@ class PluginizedContentFilter: FileFilter {
             return false
         }
 
-        // Match actual inheritancess using Regex.
+        // Match actual inheritances using Regex.
         let containsPluginizedComponentInheritance = (Regex(": *PluginizedComponent *<").firstMatch(in: content) != nil)
         if containsPluginizedComponentInheritance {
             return true

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/FileFilters/PluginizedContentFilter.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/FileFilters/PluginizedContentFilter.swift
@@ -37,17 +37,25 @@ class PluginizedContentFilter: FileFilter {
         }
 
         // Use simple string matching first since it's more performant.
-        if !content.contains("PluginizedComponent") && !content.contains("NonCoreComponent") {
+        if !content.contains("PluginizedComponent") && !content.contains("NonCoreComponent") && !content.contains("Dependency") && !content.contains("PluginExtension") {
             return false
         }
 
-        // Match actual pluginized component and non-core component inheritances using Regex.
+        // Match actual inheritancess using Regex.
         let containsPluginizedComponentInheritance = (Regex(": *PluginizedComponent *<").firstMatch(in: content) != nil)
         if containsPluginizedComponentInheritance {
             return true
         }
         let containsNonCoreComponentInheritance = (Regex(": *NonCoreComponent *<").firstMatch(in: content) != nil)
         if containsNonCoreComponentInheritance {
+            return true
+        }
+        let containsDependencyInheritance = (Regex(": *Dependency").firstMatch(in: content) != nil)
+        if containsDependencyInheritance {
+            return true
+        }
+        let containsPluginExtensionInheritance = (Regex(": *PluginExtension").firstMatch(in: content) != nil)
+        if containsPluginExtensionInheritance {
             return true
         }
 

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/OnlyDependency.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/OnlyDependency.swift
@@ -1,0 +1,7 @@
+import UIKit
+import RIBs;    import Foundation
+
+protocol Only1Dependency: Dependency {
+    var candy: Candy { get }
+    var cheese: Cheese { get }
+}

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/Pluginized/OnlyPluginExtension.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/Pluginized/OnlyPluginExtension.swift
@@ -1,0 +1,6 @@
+import UIKit
+import RIBs;    import Foundation
+
+protocol OnlyAPluginExtension: PluginExtension {
+    var whatPluginPoint: WhatPluginPoint { get }
+}

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
@@ -56,8 +56,8 @@ class DependencyGraphParserTests: AbstractParserTests {
 
         XCTAssertEqual(executor.executeCallCount, files.count)
         XCTAssertEqual(filterCount, files.count)
-        XCTAssertEqual(producerCount, 3)
-        XCTAssertEqual(parserCount, 3)
+        XCTAssertEqual(producerCount, 4)
+        XCTAssertEqual(parserCount, 4)
         XCTAssertEqual(producerCount, parserCount)
     }
 

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/FileFilterTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/FileFilterTaskTests.swift
@@ -110,4 +110,20 @@ class FileFilterTaskTests: AbstractParserTests {
             XCTFail()
         }
     }
+
+    func test_execute_onlyDependency_verifyResult() {
+        let fileUrl = fixtureUrl(for: "OnlyDependency.swift")
+        let content = try! String(contentsOf: fileUrl)
+        let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [])
+
+        let result = task.execute()
+
+        switch result {
+        case .shouldParse(let sourceUrl, let sourceContent):
+            XCTAssertEqual(sourceUrl, fileUrl)
+            XCTAssertEqual(sourceContent, content)
+        case .skip:
+            XCTFail()
+        }
+    }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizableASTParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizableASTParserTaskTests.swift
@@ -33,73 +33,70 @@ class PluginizableASTParserTaskTests: AbstractParserTests {
         let task = PluginizableASTParserTask(ast: AST(structure: structure, imports: imports))
         let node = task.execute()
 
-        XCTAssertEqual(node.components.count, 4)
 
         // Regular components.
-        let myComponent = node.components.first { (component: PluginizableASTComponent) -> Bool in
-            component.data.name == "MyComponent"
+        XCTAssertEqual(node.components.count, 2)
+        let myComponent = node.components.first { (component: ASTComponent) -> Bool in
+            component.name == "MyComponent"
         }!
-        XCTAssertEqual(myComponent.data.expressionCallTypeNames, ["Stream", "Donut", "shared", "MyChildComponent", "Basket"])
-        XCTAssertEqual(myComponent.data.name, "MyComponent")
-        XCTAssertEqual(myComponent.data.dependencyProtocolName, "MyDependency")
-        XCTAssertEqual(myComponent.data.properties.count, 4)
-        XCTAssertNil(myComponent.pluginExtensionType)
-        XCTAssertNil(myComponent.nonCoreComponentType)
-        let containsStream = myComponent.data.properties.contains { (property: Property) -> Bool in
+        XCTAssertEqual(myComponent.expressionCallTypeNames, ["Stream", "Donut", "shared", "MyChildComponent", "Basket"])
+        XCTAssertEqual(myComponent.name, "MyComponent")
+        XCTAssertEqual(myComponent.dependencyProtocolName, "MyDependency")
+        XCTAssertEqual(myComponent.properties.count, 4)
+        let containsStream = myComponent.properties.contains { (property: Property) -> Bool in
             return property.name == "stream" && property.type == "Stream"
         }
         XCTAssertTrue(containsStream)
-        let containsDonut = myComponent.data.properties.contains { (property: Property) -> Bool in
+        let containsDonut = myComponent.properties.contains { (property: Property) -> Bool in
             return property.name == "donut" && property.type == "Donut"
         }
         XCTAssertTrue(containsDonut)
-        let containsBasket = myComponent.data.properties.contains { (property: Property) -> Bool in
+        let containsBasket = myComponent.properties.contains { (property: Property) -> Bool in
             return property.name == "sweetsBasket" && property.type == "Basket"
         }
         XCTAssertTrue(containsBasket)
-        let containsChildComponent = myComponent.data.properties.contains { (property: Property) -> Bool in
+        let containsChildComponent = myComponent.properties.contains { (property: Property) -> Bool in
             return property.name == "myChildComponent" && property.type == "MyChildComponent"
         }
         XCTAssertTrue(containsChildComponent)
 
-        let my2Component = node.components.first { (component: PluginizableASTComponent) -> Bool in
-            component.data.name == "My2Component"
+        let my2Component = node.components.first { (component: ASTComponent) -> Bool in
+            component.name == "My2Component"
         }!
-        XCTAssertEqual(my2Component.data.expressionCallTypeNames, ["shared", "Wallet", "Banana", "Apple", "Book"])
-        XCTAssertEqual(my2Component.data.name, "My2Component")
-        XCTAssertEqual(my2Component.data.dependencyProtocolName, "My2Dependency")
-        XCTAssertEqual(my2Component.data.properties.count, 2)
-        XCTAssertNil(my2Component.pluginExtensionType)
-        XCTAssertNil(my2Component.nonCoreComponentType)
-        let containsBook = my2Component.data.properties.contains { (property: Property) -> Bool in
+        XCTAssertEqual(my2Component.expressionCallTypeNames, ["shared", "Wallet", "Banana", "Apple", "Book"])
+        XCTAssertEqual(my2Component.name, "My2Component")
+        XCTAssertEqual(my2Component.dependencyProtocolName, "My2Dependency")
+        XCTAssertEqual(my2Component.properties.count, 2)
+        let containsBook = my2Component.properties.contains { (property: Property) -> Bool in
             return property.name == "book" && property.type == "Book"
         }
         XCTAssertTrue(containsBook)
-        let containsOptionalWallet = my2Component.data.properties.contains { (property: Property) -> Bool in
+        let containsOptionalWallet = my2Component.properties.contains { (property: Property) -> Bool in
             return property.name == "maybeWallet" && property.type == "Wallet?"
         }
         XCTAssertTrue(containsOptionalWallet)
 
-        let someNonCoreComponent = node.components.first { (component: PluginizableASTComponent) -> Bool in
-            component.data.name == "SomeNonCoreComponent"
-            }!
-        XCTAssertEqual(someNonCoreComponent.data.expressionCallTypeNames, ["NonCoreObject", "shared", "SharedObject"])
-        XCTAssertEqual(someNonCoreComponent.data.name, "SomeNonCoreComponent")
-        XCTAssertEqual(someNonCoreComponent.data.dependencyProtocolName, "SomeNonCoreDependency")
-        XCTAssertEqual(someNonCoreComponent.data.properties.count, 2)
-        XCTAssertNil(someNonCoreComponent.pluginExtensionType)
-        XCTAssertNil(someNonCoreComponent.nonCoreComponentType)
-        let containsNewNonCoreObject = someNonCoreComponent.data.properties.contains { (property: Property) -> Bool in
+        // Non-core components.
+        XCTAssertEqual(node.nonCoreComponents.count, 1)
+        let someNonCoreComponent = node.nonCoreComponents.first { (component: ASTComponent) -> Bool in
+            component.name == "SomeNonCoreComponent"
+        }!
+        XCTAssertEqual(someNonCoreComponent.expressionCallTypeNames, ["NonCoreObject", "shared", "SharedObject"])
+        XCTAssertEqual(someNonCoreComponent.name, "SomeNonCoreComponent")
+        XCTAssertEqual(someNonCoreComponent.dependencyProtocolName, "SomeNonCoreDependency")
+        XCTAssertEqual(someNonCoreComponent.properties.count, 2)
+        let containsNewNonCoreObject = someNonCoreComponent.properties.contains { (property: Property) -> Bool in
             return property.name == "newNonCoreObject" && property.type == "NonCoreObject?"
         }
         XCTAssertTrue(containsNewNonCoreObject)
-        let containsSharedNonCoreObject = someNonCoreComponent.data.properties.contains { (property: Property) -> Bool in
+        let containsSharedNonCoreObject = someNonCoreComponent.properties.contains { (property: Property) -> Bool in
             return property.name == "sharedNonCoreObject" && property.type == "SharedObject"
         }
         XCTAssertTrue(containsSharedNonCoreObject)
 
         // Pluginized components.
-        let somePluginizedCompo = node.components.first { (component: PluginizableASTComponent) -> Bool in
+        XCTAssertEqual(node.pluginiableComponents.count, 1)
+        let somePluginizedCompo = node.pluginiableComponents.first { (component: PluginizableASTComponent) -> Bool in
             component.data.name == "SomePluginizedCompo"
         }!
         XCTAssertEqual(somePluginizedCompo.data.expressionCallTypeNames, ["LGOLEDTv"])
@@ -166,6 +163,18 @@ class PluginizableASTParserTaskTests: AbstractParserTests {
             return property.name == "maybe" && property.type == "Maybe?"
         }
         XCTAssertTrue(containsMaybe)
+
+        // Plugin extensions.
+        XCTAssertEqual(node.pluginExtensions.count, 1)
+        let bExtension = node.pluginExtensions.first { (pluginExtension: PluginExtension) -> Bool in
+            pluginExtension.name == "BExtension"
+        }!
+        XCTAssertEqual(bExtension.name, "BExtension")
+        XCTAssertEqual(bExtension.properties.count, 1)
+        let containsMyPluginPoint = bExtension.properties.contains { (property: Property) -> Bool in
+            property.name == "myPluginPoint"
+        }
+        XCTAssertTrue(containsMyPluginPoint)
 
         // Imports.
         XCTAssertEqual(node.imports, ["import UIKit", "import RIBs", "import Foundation"])

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizableFileFilterTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizableFileFilterTaskTests.swift
@@ -142,4 +142,36 @@ class PluginizableFileFilterTaskTests: AbstractPluginizedParserTests {
             XCTFail()
         }
     }
+
+    func test_execute_onlyDependency_verifyResult() {
+        let fileUrl = fixtureUrl(for: "OnlyDependency.swift")
+        let content = try! String(contentsOf: fileUrl)
+        let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [])
+
+        let result = task.execute()
+
+        switch result {
+        case .shouldParse(let sourceUrl, let sourceContent):
+            XCTAssertEqual(sourceUrl, fileUrl)
+            XCTAssertEqual(sourceContent, content)
+        case .skip:
+            XCTFail()
+        }
+    }
+
+    func test_execute_onlyPluginExtension_verifyResult() {
+        let fileUrl = pluginizedFixtureUrl(for: "OnlyPluginExtension.swift")
+        let content = try! String(contentsOf: fileUrl)
+        let task = PluginizableFileFilterTask(url: fileUrl, exclusionSuffixes: [])
+
+        let result = task.execute()
+
+        switch result {
+        case .shouldParse(let sourceUrl, let sourceContent):
+            XCTAssertEqual(sourceUrl, fileUrl)
+            XCTAssertEqual(sourceContent, content)
+        case .skip:
+            XCTFail()
+        }
+    }
 }


### PR DESCRIPTION
- Added a `PluginExtension` base protocol for filtering and parsing.
- Added plugin extension filtering and parsing.
- Added filtering for files only containing dependency protocols.
- Separated out various types of components in data model for easier processing.

Fixes #90