### PR TITLE
Add entry class for export

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
@@ -82,45 +82,11 @@ class DependencyGraphExporter {
             }
         }
 
-        let fileContents = serialize(providers, with: imports)
-
+        let fileContents = OutputSerializer(providers: providers, imports: imports).serialize()
         do {
             try fileContents.write(toFile: path, atomically: true, encoding: .utf8)
         } catch {
             throw DependencyGraphExporterError.unableToWriteFile(path)
         }
-    }
-
-    // MARK: - Private
-
-    private func serialize(_ providers: [SerializedProvider], with imports: [String]) -> String {
-        let registrationBody = providers
-            .map { (provider: SerializedProvider) in
-                provider.registration
-            }
-            .joined()
-            .replacingOccurrences(of: "\n", with: "\n    ")
-
-        let providersSection = providers
-            .map { (provider: SerializedProvider) in
-                provider.content
-            }
-            .joined()
-
-        let importsJoined = imports.joined(separator: "\n")
-
-        return """
-        \(importsJoined)
-
-        // MARK: - Dependency Provider Factories
-
-        func registerDependencyProviderFactories() {
-            \(registrationBody)
-        }
-
-        // MARK: - Dependency Providers
-
-        \(providersSection)
-        """
     }
 }

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyGraphExporter.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyGraphExporter.swift
@@ -1,0 +1,108 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The generation phase entry class that executes tasks to process dependency
+/// graph components, inlcuding pluginized and non-core ones, into necessary
+/// dependency providers and their registrations, then exports the contents to
+/// the destination path.
+class PluginizedDependencyGraphExporter {
+
+    /// Generate the necessary dependency provider and plugin extension source
+    /// code for the given components and pluginized components, and export
+    /// the source code to the given destination path.
+    ///
+    /// - parameter components: Array of Components to generate dependnecy
+    /// providers for
+    /// - parameter pluginizedComponents: Array of pluginized components to
+    /// generate plugin extensions and dependnecy providers for.
+    /// - parameter imports: The import statements.
+    /// - parameter to: Path to file where we want the results written to.
+    /// - parameter using: The executor to use for concurrent computation of
+    /// the dependency provider bodies.
+    /// - throws: `DependencyGraphExporterError.timeout` if computation times out.
+    /// - throws: `DependencyGraphExporterError.unableToWriteFile` if the file
+    /// write fails.
+    func export(_ components: [Component], _ pluginizedComponents: [PluginizedComponent], with imports: [String], to path: String, using executor: SequenceExecutor) throws {
+        let dependencyProviderHandleTuples = enqueueExportDependencyProviders(for: components, pluginizedComponents, using: executor)
+        let pluginExtensionHandleTuples = enqueueExportPluginExtensions(for: pluginizedComponents, using: executor)
+        let serializedProviders = try awaitSerialization(using: dependencyProviderHandleTuples + pluginExtensionHandleTuples)
+
+        let fileContents = OutputSerializer(providers: serializedProviders, imports: imports).serialize()
+        do {
+            try fileContents.write(toFile: path, atomically: true, encoding: .utf8)
+        } catch {
+            throw DependencyGraphExporterError.unableToWriteFile(path)
+        }
+    }
+
+    // MARK: - Private
+
+    private func enqueueExportDependencyProviders(for components: [Component], _ pluginizedComponents: [PluginizedComponent], using executor: SequenceExecutor) -> [(SequenceExecutionHandle<[SerializedProvider]>, String)] {
+        let pluginizedData = pluginizedComponents.map { (component: PluginizedComponent) -> Component in
+            component.data
+        }
+        let allComponents = components + pluginizedData
+
+        var taskHandleTuples = [(handle: SequenceExecutionHandle<[SerializedProvider]>, componentName: String)]()
+        for component in allComponents {
+            let initialTask = DependencyProviderDeclarerTask(component: component)
+            let taskHandle = executor.executeSequence(from: initialTask) { (currentTask: Task, currentResult: Any) -> SequenceExecution<[SerializedProvider]> in
+                if currentTask is DependencyProviderDeclarerTask, let providers = currentResult as? [DependencyProvider] {
+                    return .continueSequence(PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents))
+                } else if currentTask is PluginizedDependencyProviderContentTask, let processedProviders = currentResult as? [PluginizedProcessedDependencyProvider] {
+                    return .continueSequence(PluginizedDependencyProviderSerializerTask(providers: processedProviders))
+                } else if currentTask is PluginizedDependencyProviderSerializerTask, let serializedProviders = currentResult as? [SerializedProvider] {
+                    return .endOfSequence(serializedProviders)
+                } else {
+                    fatalError("Unhandled task \(currentTask) with result \(currentResult)")
+                }
+            }
+            taskHandleTuples.append((taskHandle, component.name))
+        }
+
+        return taskHandleTuples
+    }
+
+    private func enqueueExportPluginExtensions(for pluginizedComponents: [PluginizedComponent], using executor: SequenceExecutor) -> [(SequenceExecutionHandle<[SerializedProvider]>, String)] {
+        var taskHandleTuples = [(handle: SequenceExecutionHandle<[SerializedProvider]>, pluginExtensionName: String)]()
+        for component in pluginizedComponents {
+            let task = PluginExtensionSerializerTask(component: component)
+            let taskHandle = executor.executeSequence(from: task) { (currentTask: Task, currentResult: Any) -> SequenceExecution<[SerializedProvider]> in
+                return .endOfSequence([currentResult as! SerializedProvider])
+            }
+            taskHandleTuples.append((taskHandle, component.pluginExtension.name))
+        }
+
+        return taskHandleTuples
+    }
+
+    private func awaitSerialization(using taskHandleTuples: [(SequenceExecutionHandle<[SerializedProvider]>, String)]) throws -> [SerializedProvider] {
+        var providers = [SerializedProvider]()
+        for (taskHandle, compnentName) in taskHandleTuples {
+            do {
+                let provider = try taskHandle.await(withTimeout: 30)
+                providers.append(contentsOf: provider)
+            } catch SequenceExecutionError.awaitTimeout  {
+                throw DependencyGraphExporterError.timeout(compnentName)
+            } catch {
+                fatalError("Unhandled task execution error \(error)")
+            }
+        }
+        return providers
+    }
+}

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The task that serializes a list of pluginized processed dependency
+/// providers into exportable foramt.
+class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
+
+    /// Initializer.
+    ///
+    /// - parameter providers: The pluginized processed dependency provider
+    /// to serialize.
+    init(providers: [PluginizedProcessedDependencyProvider]) {
+        self.providers = providers
+    }
+
+    /// Execute the task and returns the in-memory serialized dependency
+    /// provider data models.
+    ///
+    /// - returns: The list of `SerializedProvider`.
+    override func execute() -> [SerializedProvider] {
+        return providers.map { (provider: PluginizedProcessedDependencyProvider) in
+            return serialize(provider)
+        }
+    }
+
+    // MARK: - Private
+
+    private let providers: [PluginizedProcessedDependencyProvider]
+
+    private func serialize(_ provider: PluginizedProcessedDependencyProvider) -> SerializedProvider {
+        let content = serializedContent(for: provider)
+        let registration = DependencyProviderRegistrationSerializer(provider: provider.data).serialize()
+        return SerializedProvider(content: content, registration: registration)
+    }
+
+    private func serializedContent(for provider: PluginizedProcessedDependencyProvider) -> String {
+        let classNameSerializer = DependencyProviderClassNameSerializer(provider: provider.data)
+        let propertiesSerializer = PluginizedPropertiesSerializer(provider: provider)
+        let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: Array(provider.data.levelMap.keys))
+        let initBodySerializer = DependencyProviderInitBodySerializer(provider: provider.data)
+
+        let serializer = DependencyProviderSerializer(provider: provider.data, classNameSerializer: classNameSerializer, propertiesSerializer: propertiesSerializer, sourceComponentsSerializer: sourceComponentsSerializer, initBodySerializer: initBodySerializer)
+        return serializer.serialize()
+    }
+}

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A utility class that serializes a set of providers and necessary
+/// import statements into the final output file content.
+class OutputSerializer: Serializer {
+
+    /// Initializer.
+    ///
+    /// - parameter providers: The list of providers to output.
+    /// - parameter imports: The list of import statements to include.
+    init(providers: [SerializedProvider], imports: [String]) {
+        self.providers = providers
+        self.imports = imports
+    }
+
+    /// Serialize the data model into source code.
+    ///
+    /// - returns: The source code `String`.
+    func serialize() -> String {
+        let registrationBody = providers
+            .map { (provider: SerializedProvider) in
+                provider.registration
+            }
+            .joined()
+            .replacingOccurrences(of: "\n", with: "\n    ")
+
+        let providersSection = providers
+            .map { (provider: SerializedProvider) in
+                provider.content
+            }
+            .joined()
+
+        let importsJoined = imports.joined(separator: "\n")
+
+        return """
+        \(importsJoined)
+
+        // MARK: - Registration
+
+        func registerProviderFactories() {
+            \(registrationBody)
+        }
+
+        // MARK: - Providers
+
+        \(providersSection)
+        """
+    }
+
+    // MARK: - Private
+
+    private let providers: [SerializedProvider]
+    private let imports: [String]
+}

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/Pluginized/PluginizedPropertiesSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/Pluginized/PluginizedPropertiesSerializer.swift
@@ -61,9 +61,9 @@ class PluginizedPropertiesSerializer: Serializer {
         }()
 
         return """
-        var \(property.data.unprocessed.name): \(property.data.unprocessed.type) {
-            return \(auxillaryPrefix)\(property.data.sourceComponentType.lowercasedFirstChar())\(auxillaryAccessor)\(auxillarySuffix).\(property.data.unprocessed.name)
-        }
+            var \(property.data.unprocessed.name): \(property.data.unprocessed.type) {
+                return \(auxillaryPrefix)\(property.data.sourceComponentType.lowercasedFirstChar())\(auxillaryAccessor)\(auxillarySuffix).\(property.data.unprocessed.name)
+            }
         """
     }
 }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
@@ -123,7 +123,8 @@ class PluginizedDependencyGraphParser {
             }
         }
 
-        let valueTypeComponents = components.map { (astComponent: ASTComponent) -> Component in
+        // Return back non-core components as well since they can be treated as any regular component.
+        let valueTypeComponents = (components + nonCoreComponents).map { (astComponent: ASTComponent) -> Component in
             astComponent.valueType
         }
         let valueTypePluginizedComponents = pluginizedComponents.map { (astComponent: PluginizedASTComponent) -> PluginizedComponent in

--- a/Generator/Tests/LinuxMain.swift
+++ b/Generator/Tests/LinuxMain.swift
@@ -37,4 +37,5 @@ XCTMain([
     testCase(PluginizedDependencyGraphParserTests.allTests),
     testCase(PluginizedDependencyProviderContentTaskTests.allTests),
     testCase(PluginizedPropertiesSerializerTests.allTests),
+    testCase(PluginizedDependencyGraphExporterTests.allTests),
 ])

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/Pluginized/generated.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/Pluginized/generated.swift
@@ -1,19 +1,3 @@
-//
-//  Copyright (c) 2018. Uber Technologies
-//
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-//
-
 import NeedleFoundation
 import RxSwift
 import ScoreSheet
@@ -53,7 +37,7 @@ func registerProviderFactories() {
     __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: "LoggedInComponent") { component in
         return LoggedInPluginExtensionProvider(component: component)
     }
-
+    
 }
 
 // MARK: - Providers
@@ -128,4 +112,3 @@ private class LoggedInPluginExtensionProvider: LoggedInPluginExtension {
         loggedInNonCoreComponent = loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent
     }
 }
-

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/generated.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/generated.swift
@@ -2,9 +2,9 @@ import NeedleFoundation
 import RxSwift
 import UIKit
 
-// MARK: - Dependency Provider Factories
+// MARK: - Registration
 
-func registerDependencyProviderFactories() {
+func registerProviderFactories() {
     __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent") { component in
         return GameDependency_2401566548657102800Provider(component: component)
     }
@@ -26,7 +26,7 @@ func registerDependencyProviderFactories() {
     
 }
 
-// MARK: - Dependency Providers
+// MARK: - Providers
 
 /// ^->RootComponent->LoggedInComponent->GameComponent
 private class GameDependency_2401566548657102800Provider: GameDependency {

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
@@ -1,0 +1,47 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+import XCTest
+@testable import NeedleFramework
+
+class PluginizedDependencyGraphExporterTests: AbstractPluginizedGeneratorTests {
+    let fixturesURL = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Fixtures/Pluginized")
+
+    @available(OSX 10.12, *)
+    static var allTests = [
+        ("test_export_verifyContent", test_export_verifyContent),
+    ]
+
+    @available(OSX 10.12, *)
+    func test_export_verifyContent() {
+        let (components, pluginizedComponents, imports) = pluginizedSampleProjectParsed()
+        let executor = MockSequenceExecutor()
+        let exporter = PluginizedDependencyGraphExporter()
+
+        let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("generated_pluginized.swift")
+        try? exporter.export(components, pluginizedComponents, with: imports, to: outputURL.path, using: executor)
+        let generated = try? String(contentsOf: outputURL)
+        XCTAssertNotNil(generated, "Could not read the generated file")
+
+        let url = fixturesURL.appendingPathComponent("generated.swift")
+        let expected = try? String(contentsOf: url)
+        XCTAssertNotNil(expected, "Could not read in fixture file")
+
+        XCTAssertEqual(generated, expected)
+    }
+}

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyProviderContentTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyProviderContentTaskTests.swift
@@ -42,7 +42,7 @@ class PluginizedDependencyProviderContentTaskTests: AbstractPluginizedGeneratorT
         let task = PluginizedDependencyProviderContentTask(providers: allProviders, pluginizedComponents: pluginizedComponents)
         let allProcessedProviders = task.execute()
 
-        XCTAssertEqual(allProcessedProviders.count, 6)
+        XCTAssertEqual(allProcessedProviders.count, 8)
         verify(allProcessedProviders)
     }
 
@@ -63,14 +63,14 @@ class PluginizedDependencyProviderContentTaskTests: AbstractPluginizedGeneratorT
         XCTAssertEqual(providers[3].processedProperties[0].data.sourceComponentType, "LoggedInNonCoreComponent")
         XCTAssertEqual(providers[3].processedProperties[0].auxillarySourceType, nil)
 
-        XCTAssertEqual(providers[4].data.levelMap["LoggedInComponent"], 1)
-        XCTAssertEqual(providers[4].data.levelMap["RootComponent"], 2)
-        XCTAssertEqual(providers[4].processedProperties[0].data.unprocessed.name, "mutableScoreStream")
-        XCTAssertEqual(providers[4].processedProperties[0].auxillarySourceName, "LoggedInPluginExtension")
-        XCTAssertEqual(providers[4].processedProperties[0].data.sourceComponentType, "LoggedInComponent")
-        XCTAssertEqual(providers[4].processedProperties[0].auxillarySourceType, .pluginExtension)
-        XCTAssertEqual(providers[4].processedProperties[1].data.unprocessed.name, "playersStream")
-        XCTAssertEqual(providers[4].processedProperties[1].data.sourceComponentType, "RootComponent")
-        XCTAssertEqual(providers[4].processedProperties[1].auxillarySourceType, nil)
+        XCTAssertEqual(providers[6].data.levelMap["LoggedInComponent"], 1)
+        XCTAssertEqual(providers[6].data.levelMap["RootComponent"], 2)
+        XCTAssertEqual(providers[6].processedProperties[0].data.unprocessed.name, "mutableScoreStream")
+        XCTAssertEqual(providers[6].processedProperties[0].auxillarySourceName, "LoggedInPluginExtension")
+        XCTAssertEqual(providers[6].processedProperties[0].data.sourceComponentType, "LoggedInComponent")
+        XCTAssertEqual(providers[6].processedProperties[0].auxillarySourceType, .pluginExtension)
+        XCTAssertEqual(providers[6].processedProperties[1].data.unprocessed.name, "playersStream")
+        XCTAssertEqual(providers[6].processedProperties[1].data.sourceComponentType, "RootComponent")
+        XCTAssertEqual(providers[6].processedProperties[1].auxillarySourceType, nil)
     }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Serializers/Pluginized/PluginizedPropertiesSerializerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Serializers/Pluginized/PluginizedPropertiesSerializerTests.swift
@@ -33,6 +33,9 @@ class PluginizedPropertiesSerializerTests: AbstractPluginizedGeneratorTests {
             let providers = DependencyProviderDeclarerTask(component: component).execute()
             let processedProviders = PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents).execute()
             for provider in processedProviders {
+                if provider.processedProperties.isEmpty {
+                    continue
+                }
                 let serializedProperties = PluginizedPropertiesSerializer(provider: provider).serialize()
                 flattenContents += serializedProperties + "\n"
             }
@@ -49,22 +52,21 @@ class PluginizedPropertiesSerializerTests: AbstractPluginizedGeneratorTests {
 
         let expected =
         """
-        var mutablePlayersStream: MutablePlayersStream {
-            return rootComponent.mutablePlayersStream
-        }
-
-        var scoreStream: ScoreStream {
-            return (loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent).scoreStream
-        }
-        var scoreStream: ScoreStream {
-            return loggedInNonCoreComponent.scoreStream
-        }
-        var mutableScoreStream: MutableScoreStream {
-            return loggedInComponent.pluginExtension.mutableScoreStream
-        }
-        var playersStream: PlayersStream {
-            return rootComponent.playersStream
-        }
+            var mutablePlayersStream: MutablePlayersStream {
+                return rootComponent.mutablePlayersStream
+            }
+            var scoreStream: ScoreStream {
+                return (loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent).scoreStream
+            }
+            var scoreStream: ScoreStream {
+                return loggedInNonCoreComponent.scoreStream
+            }
+            var mutableScoreStream: MutableScoreStream {
+                return loggedInComponent.pluginExtension.mutableScoreStream
+            }
+            var playersStream: PlayersStream {
+                return rootComponent.playersStream
+            }
 
 
         """

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
@@ -75,7 +75,7 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
             let childComponent = components.filter { $0.name == "MyChildComponent" }.first!
             let parentComponent = components.filter { $0.name == "MyComponent" }.first!
             XCTAssertTrue(childComponent.parents.first! == parentComponent)
-            XCTAssertEqual(components.count, 5)
+            XCTAssertEqual(components.count, 8)
             XCTAssertEqual(pluginizedComponents.count, 2)
             XCTAssertEqual(imports, ["import Foundation", "import NeedleFoundation", "import NeedleFoundationExtension", "import RIBs", "import RxSwift", "import ScoreSheet", "import UIKit", "import Utility"])
         } catch {

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/AppDelegate.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/AppDelegate.swift
@@ -23,8 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        registerDependencyProviderFactories()
-        registerPluginExtensionProviderFactories()
+        registerProviderFactories()
 
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window


### PR DESCRIPTION
- Add `PluginizedDependencyGraphExporter` as the entry point for export.
- Updated parsing stage to return back non-core components as part of the regulard components.
- Fixed pluginized property serialization indentation.