### PR TITLE
Add a command-line flag to allow single threaded execution

### DIFF
--- a/Generator/Sources/NeedleFramework/Execution/SequenceExecutor.swift
+++ b/Generator/Sources/NeedleFramework/Execution/SequenceExecutor.swift
@@ -122,6 +122,45 @@ class SequenceExecutorImpl: SequenceExecutor {
     }
 }
 
+/// Executor of sequences of tasks using the main queue.
+/// This exists only to assist with debugging
+///
+/// - seeAlso: `SequencedTask`.
+class SequenceExecutorSerialImpl: SequenceExecutor {
+
+    /// Execute a sequence of tasks from the given initial task.
+    ///
+    /// - parameter initialTask: The root task of the sequence of tasks
+    /// to be executed.
+    /// - parameter execution: The execution defining the sequence of tasks.
+    /// When a task completes its execution, this closure is invoked with
+    /// the task and its produced result.
+    /// - returns: The execution handle that allows control and monitoring
+    /// of the sequence of tasks being executed.
+    func executeSequence<SequenceResultType>(from initialTask: Task, with execution: @escaping (Task, Any) -> SequenceExecution<SequenceResultType>) -> SequenceExecutionHandle<SequenceResultType> {
+        let handle: SequenceExecutionHandleImpl<SequenceResultType> = SequenceExecutionHandleImpl()
+        execute(initialTask, with: handle, execution)
+        return handle
+    }
+
+    // MARK: - Private
+
+    private func execute<SequenceResultType>(_ task: Task, with sequenceHandle: SequenceExecutionHandleImpl<SequenceResultType>, _ execution: @escaping (Task, Any) -> SequenceExecution<SequenceResultType>) {
+        guard !sequenceHandle.isCancelled else {
+            return
+        }
+
+        let result = task.typeErasedExecute()
+        let nextExecution = execution(task, result)
+        switch nextExecution {
+        case .continueSequence(let nextTask):
+            self.execute(nextTask, with: sequenceHandle, execution)
+        case .endOfSequence(let result):
+            sequenceHandle.sequenceDidComplete(with: result)
+        }
+    }
+}
+
 private class SequenceExecutionHandleImpl<SequenceResultType>: SequenceExecutionHandle<SequenceResultType> {
 
     private let latch = CountDownLatch(count: 1)

--- a/Generator/Sources/NeedleFramework/Needle.swift
+++ b/Generator/Sources/NeedleFramework/Needle.swift
@@ -31,9 +31,9 @@ public class Needle {
     /// - parameter additionalImports: The additional import statements to add
     /// to the ones parsed from source files.
     /// - parameter destinationPath: The path to export generated code to.
-    public static func generate(from sourceRootPath: String, excludingFilesWithSuffixes exclusionSuffixes: [String], withAdditionalImports additionalImports: [String], to destinationPath: String) {
+    public static func generate(from sourceRootPath: String, excludingFilesWithSuffixes exclusionSuffixes: [String], withAdditionalImports additionalImports: [String], to destinationPath: String, singleThreaded: Bool = false) {
         let sourceRootUrl = URL(fileURLWithPath: sourceRootPath)
-        let executor = SequenceExecutorImpl(name: "Needle.generate", qos: .userInteractive)
+        let executor: SequenceExecutor = singleThreaded ? SequenceExecutorSerialImpl() : SequenceExecutorImpl(name: "Needle.generate", qos: .userInteractive)
         let parser = DependencyGraphParser()
         do {
             let (components, imports) = try parser.parse(from: sourceRootUrl, excludingFilesWithSuffixes: exclusionSuffixes, using: executor)

--- a/Generator/Sources/NeedleFramework/Pluginized/PluginizedNeedle.swift
+++ b/Generator/Sources/NeedleFramework/Pluginized/PluginizedNeedle.swift
@@ -29,9 +29,9 @@ public class PluginizedNeedle {
     /// - parameter additionalImports: The additional import statements to add
     /// to the ones parsed from source files.
     /// - parameter destinationPath: The path to export generated code to.
-    public static func generate(from sourceRootPath: String, excludingFilesWithSuffixes exclusionSuffixes: [String], withAdditionalImports additionalImports: [String], to destinationPath: String) {
+    public static func generate(from sourceRootPath: String, excludingFilesWithSuffixes exclusionSuffixes: [String], withAdditionalImports additionalImports: [String], to destinationPath: String, singleThreaded: Bool = false) {
         let sourceRootUrl = URL(fileURLWithPath: sourceRootPath)
-        let executor = SequenceExecutorImpl(name: "PluginizedNeedle.generate", qos: .userInteractive)
+        let executor: SequenceExecutor = singleThreaded ? SequenceExecutorSerialImpl() : SequenceExecutorImpl(name: "PluginizedNeedle.generate", qos: .userInteractive)
         let parser = PluginizedDependencyGraphParser()
         do {
             let (components, pluginizedComponents, imports) = try parser.parse(from: sourceRootUrl, excludingFilesWithSuffixes: exclusionSuffixes, using: executor)

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -34,13 +34,15 @@ class GenerateCommand: Command {
     private let suffixes: OptionArgument<[String]>
     private let additionalImports: OptionArgument<[String]>
     private let scanPlugins: OptionArgument<Bool>
+    private let singleThreaded: OptionArgument<Bool>
 
     required init(parser: ArgumentParser) {
         let subparser = parser.add(subparser: name, overview: overview)
         sourceRootPath = subparser.add(positional: "sourceRootPath", kind: String.self, usage: "Path to the root folder of Swift source files.", completion: .filename)
         destinationPath = subparser.add(positional: "destinationPath", kind: String.self, usage: "Path to the destination file of generated Swift DI code.", completion: .filename)
         suffixes = subparser.add(option: "--suffixes", shortName: "-sfx", kind: [String].self, usage: "Filename suffix(es) without extensions to exclude from parsing.", completion: .filename)
-        scanPlugins = subparser.add(option: "--pluginized", shortName: "-p", kind: Bool.self, usage: "Whether or not to consider plugins when parsing.", completion: .filename)
+        scanPlugins = subparser.add(option: "--pluginized", shortName: "-p", kind: Bool.self, usage: "Whether or not to consider plugins when parsing.")
+        singleThreaded = subparser.add(option: "--single-threaded", shortName: "-st", kind: Bool.self, usage: "Use only one thread (useful for debugging.")
         additionalImports = subparser.add(option: "--additional-imports", shortName: "-ai", kind: [String].self, usage: "Additional modules to import in the generated file, in addition to the ones parsed from source files.", completion: .none)
     }
 
@@ -50,10 +52,11 @@ class GenerateCommand: Command {
                 let suffixes = arguments.get(self.suffixes) ?? []
                 let additionalImports = arguments.get(self.additionalImports) ?? []
                 let scanPlugins = arguments.get(self.scanPlugins) ?? false
+                let singleThreaded = arguments.get(self.singleThreaded) ?? false
                 if scanPlugins {
-                    PluginizedNeedle.generate(from: sourceRootPath, excludingFilesWithSuffixes: suffixes, withAdditionalImports: additionalImports, to: destinationPath)
+                    PluginizedNeedle.generate(from: sourceRootPath, excludingFilesWithSuffixes: suffixes, withAdditionalImports: additionalImports, to: destinationPath, singleThreaded: singleThreaded)
                 } else {
-                    Needle.generate(from: sourceRootPath, excludingFilesWithSuffixes: suffixes, withAdditionalImports: additionalImports, to: destinationPath)
+                    Needle.generate(from: sourceRootPath, excludingFilesWithSuffixes: suffixes, withAdditionalImports: additionalImports, to: destinationPath, singleThreaded: singleThreaded)
                 }
             } else {
                 fatalError("Missing destination path.")


### PR DESCRIPTION
- This greatly simplifies the debugging process.
- Also a very quick-and-dirty way to measure the benefits of multi-threading.