### PR TITLE
Remove references to RIB specific concepts

### DIFF
--- a/Foundation/Sources/NeedleFoundation/Pluginized/NonCoreComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/NonCoreComponent.swift
@@ -20,7 +20,7 @@ import Foundation
 /// support scope activation and deactivation.
 ///
 /// - note: A separate protocol is used to allow `PluginizableComponent`
-/// to delcare a non-core component generic without having to specify the
+/// to declare a non-core component generic without having to specify the
 /// dependency protocol nested generics.
 public protocol NonCoreComponentType: AnyObject {
     /// Initializer.

--- a/Foundation/Sources/NeedleFoundation/Pluginized/NonCoreComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/NonCoreComponent.swift
@@ -32,7 +32,7 @@ public protocol NonCoreComponentType: AnyObject {
     /// activating this non-core component as well.
     ///
     /// - note: This method is automatically invoked when the non-core component
-    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// is paired with a `PluginizableComponent` that is bound to a lifecycle.
     /// Otherwise, this method must be explicitly invoked.
     func scopeDidBecomeActive()
 
@@ -40,7 +40,7 @@ public protocol NonCoreComponentType: AnyObject {
     /// deactivating this non-core component as well.
     ///
     /// - note: This method is automatically invoked when the non-core component
-    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// is paired with a `PluginizableComponent` that is bound to a lifecycle.
     /// Otherwise, this method must be explicitly invoked.
     func scopeDidBecomeInactive()
 }
@@ -60,7 +60,7 @@ open class NonCoreComponent<DependencyType>: Component<DependencyType>, NonCoreC
     /// activating this non-core component as well.
     ///
     /// - note: This method is automatically invoked when the non-core component
-    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// is paired with a `PluginizableComponent` that is bound to a lifecycle.
     /// Otherwise, this method must be explicitly invoked.
     open func scopeDidBecomeActive() {}
 
@@ -68,7 +68,7 @@ open class NonCoreComponent<DependencyType>: Component<DependencyType>, NonCoreC
     /// deactivating this non-core component as well.
     ///
     /// - note: This method is automatically invoked when the non-core component
-    /// is paired with a `PluginizableComponent` that is bound to a `Router`.
+    /// is paired with a `PluginizableComponent` that is bound to a lifecycle.
     /// Otherwise, this method must be explicitly invoked.
     open func scopeDidBecomeInactive() {}
 }

--- a/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
@@ -20,13 +20,13 @@ import Foundation
 /// pairing methods to manage its and its corresponding non-core component's
 /// lifecycle.
 ///
-/// - note: A separate protocol is used to allow `PluginizedBuilder` to
-/// delcare a pluginized component generic without having to specify the
-/// nested generics.
+/// - note: A separate protocol is used to allow the consumer to delcare
+/// a pluginized component generic without having to specify the nested
+/// generics.
 public protocol PluginizedComponentType: ComponentType {
-    /// Bind the plugnizable component to the router's lifecycle. This ensures
-    /// the associated non-core component is released when the given router scope
-    /// is deallocated.
+    /// Bind the plugnizable component to the a lifecycle. This ensures
+    /// the associated non-core component is released when the given
+    /// scope is deallocated.
     ///
     /// - note: This method must be invoked when using a `PluginizedComponent`,
     /// to avoid memory leak of the component and the non-core component.
@@ -36,11 +36,11 @@ public protocol PluginizedComponentType: ComponentType {
     /// - parameter lifecycle: The `PluginizedLifecycle` to bind to.
     func bind(to lifecycle: PluginizedLifecycle)
 
-    /// Signal the corresponding `PluginizedBuilder` is about to deinit.
-    /// This allows the pluginized component to release its corresponding
-    /// non-core component, breaking the retain cycle between it and its
-    /// non-core component.
-    func builderWillDeinit()
+    /// Signal this pluginized component that the corresponding consumer
+    /// is about to deinit. This allows the pluginized component to release
+    /// its corresponding non-core component, breaking the retain cycle
+    /// between it and its non-core component.
+    func consumerWillDeinit()
 }
 
 /// The base protocol of a plugin extension, enabling Needle's parsing process.
@@ -72,9 +72,9 @@ open class PluginizedComponent<DependencyType, PluginExtensionType, NonCoreCompo
         pluginExtension = createPluginExtensionProvider()
     }
 
-    /// Bind the plugnizable component to the router's lifecycle. This ensures
-    /// the associated non-core component is released when the given router scope
-    /// is deallocated.
+    /// Bind the plugnizable component to the a lifecycle. This ensures
+    /// the associated non-core component is released when the given
+    /// scope is deallocated.
     ///
     /// - note: This method must be invoked when using a `PluginizedComponent`,
     /// to avoid memory leak of the component and the non-core component.
@@ -96,16 +96,17 @@ open class PluginizedComponent<DependencyType, PluginExtensionType, NonCoreCompo
         }
     }
 
-    /// Signal the corresponding `PluginizedBuilder` is about to deinit.
-    /// This allows the pluginized component to release its corresponding
-    /// non-core component, breaking the retain cycle between it and its
-    /// non-core component.
-    public func builderWillDeinit() {
-        // Only release the non-core component after the builder, which should be the owner
-        // reference to the component is released. Cannot release the non-core component when
-        // the bound router is detached. The builder may build another instance of the RIB
-        // with the same instance of this component again. In that case, this component will
-        // try to access its released non-core component to recreate plugin points.
+    /// Signal this pluginized component that the corresponding consumer
+    /// is about to deinit. This allows the pluginized component to release
+    /// its corresponding non-core component, breaking the retain cycle
+    /// between it and its non-core component.
+    public func consumerWillDeinit() {
+        // Only release the non-core component after the consumer, which should
+        // be the owner reference to the component is released. Cannot release
+        // the non-core component when the bound lifecyle is deactivated. The
+        // consumer may later require the same instance of this component again.
+        // In that case, this component will try to access its released non-core
+        // component to recreate plugins.
         self.releasableNonCoreComponent = nil
     }
 

--- a/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
@@ -20,7 +20,7 @@ import Foundation
 /// pairing methods to manage its and its corresponding non-core component's
 /// lifecycle.
 ///
-/// - note: A separate protocol is used to allow the consumer to delcare
+/// - note: A separate protocol is used to allow the consumer to declare
 /// a pluginized component generic without having to specify the nested
 /// generics.
 public protocol PluginizedComponentType: ComponentType {

--- a/Foundation/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
@@ -63,7 +63,7 @@ class PluginizedComponentTests: XCTestCase {
         XCTAssertEqual(noncoreComponent!.scopeDidBecomeInactiveCallCount, 1)
     }
 
-    func test_builderWillDeinit_verifyReleasingNonCoreComponent() {
+    func test_consumerWillDeinit_verifyReleasingNonCoreComponent() {
         let mockPluginizedComponent = MockPluginizedComponent()
         var noncoreComponent: MockNonCoreComponent? = mockPluginizedComponent.nonCoreComponent as? MockNonCoreComponent
         var noncoreDeinitCallCount = 0
@@ -82,7 +82,7 @@ class PluginizedComponentTests: XCTestCase {
         XCTAssertNil(noncoreComponent)
         XCTAssertEqual(noncoreDeinitCallCount, 0)
 
-        mockPluginizedComponent.builderWillDeinit()
+        mockPluginizedComponent.consumerWillDeinit()
 
         XCTAssertNil(noncoreComponent)
         XCTAssertEqual(noncoreDeinitCallCount, 1)


### PR DESCRIPTION
`PluginizedComponent` and `NonCoreComponent` can be used independent of RIBs. Fixes #126