### PR TITLE
Ignore Module names when parsing dependency protocol names

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
@@ -76,6 +76,10 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
             }
             .first
         if let result = result {
+            if result.contains(".") {
+                // Contains a module name, strip this out
+                return result.components(separatedBy: ".").last ?? result
+            }
             return result
         } else {
             fatalError("\(name) is being parsed as a Component. Yet its generic dependency type cannot be parsed. \(inheritedTypes)")

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/NamespacedComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/NamespacedComponentSample.swift
@@ -5,7 +5,7 @@ protocol NamespacedDep: NeedleFoundation.Dependency {
     var blah: Blah { get }
 }
 
-class NamespacedComp: NeedleFoundation.Component<NamespacedDep> {
+class NamespacedComp: NeedleFoundation.Component<NeedleFoundation.NamespacedDep> {
     var donut: Donut {
         return Donut()
     }


### PR DESCRIPTION
- If we don't this confuses our linker phases.