### PR TITLE
Fix typo in Foundation protocol

### DIFF
--- a/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
@@ -33,9 +33,9 @@ public protocol PluginizedComponentType: ComponentType {
     /// - note: This method is required, because the non-core component
     /// reference cannot be made weak. If the non-core component is weak,
     /// it is deallocated before the plugin points are created lazily.
-    /// - parameter observable: The `PluginizedScopeLifecycleObervable` to
+    /// - parameter observable: The `PluginizedScopeLifecycleObservable` to
     /// bind to.
-    func bind(to observable: PluginizedScopeLifecycleObervable)
+    func bind(to observable: PluginizedScopeLifecycleObservable)
 }
 
 /// The base protocol of a plugin extension, enabling Needle's parsing process.
@@ -79,9 +79,9 @@ open class PluginizedComponent<DependencyType, PluginExtensionType, NonCoreCompo
     /// - note: This method is required, because the non-core component
     /// reference cannot be made weak. If the non-core component is weak,
     /// it is deallocated before the plugin points are created lazily.
-    /// - parameter observable: The `PluginizedScopeLifecycleObervable` to
+    /// - parameter observable: The `PluginizedScopeLifecycleObservable` to
     /// bind to.
-    public func bind(to observable: PluginizedScopeLifecycleObervable) {
+    public func bind(to observable: PluginizedScopeLifecycleObservable) {
         guard lifecycleObserverDisposable == nil else {
             return
         }

--- a/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedScopeLifecycle.swift
+++ b/Foundation/Sources/NeedleFoundation/Pluginized/PluginizedScopeLifecycle.swift
@@ -41,7 +41,7 @@ public protocol ObserverDisposable {
 }
 
 /// The observable of the lifecycle events of a pluginized scope.
-public protocol PluginizedScopeLifecycleObervable {
+public protocol PluginizedScopeLifecycleObservable {
 
     /// Observe the lifecycle events with given observer.
     ///

--- a/Foundation/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
@@ -123,7 +123,7 @@ class MockPluginizedComponent: PluginizedComponent<EmptyDependency, EmptyPluginE
     }
 }
 
-class MockPluginizedScopeLifecycleObervable: PluginizedScopeLifecycleObervable {
+class MockPluginizedScopeLifecycleObervable: PluginizedScopeLifecycleObservable {
 
     let disposable: ObserverDisposable
 


### PR DESCRIPTION
`PluginizedScopeLifecycleObervable` should be `PluginizedScopeLifecycleObservable`.