### PR TITLE
Ensure expression call names are unique

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
@@ -53,11 +53,11 @@ class PluginizedASTParserTask: AbstractTask<PluginizedDependencyGraphNode> {
             if let substructure = item as? [String: SourceKitRepresentable] {
                 if substructure.isPluginizedComponent {
                     let (dependencyProtocolName, pluginExtensionName, nonCoreComponentName) = substructure.pluginizedGenerics
-                    let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.expressionCallNames)
+                    let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
                     pluginizedComponents.append(PluginizedASTComponent(data: component, pluginExtensionType: pluginExtensionName, nonCoreComponentType: nonCoreComponentName))
                 } else if substructure.isNonCoreComponent {
                     let dependencyProtocolName = substructure.dependencyProtocolName(for: "NonCoreComponent")
-                    let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.expressionCallNames)
+                    let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
                     nonCoreComponents.append(component)
                 } else if substructure.isPluginExtension {
                     pluginExtensions.append(PluginExtension(name: substructure.name, properties: substructure.properties))

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
@@ -49,7 +49,7 @@ class ASTParserTask: AbstractTask<DependencyGraphNode> {
             if let substructure = item as? [String: SourceKitRepresentable] {
                 if substructure.isComponent {
                     let dependencyProtocolName = substructure.dependencyProtocolName(for: "Component")
-                    components.append(ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.expressionCallNames))
+                    components.append(ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames))
                 } else if substructure.isDependencyProtocol {
                     dependencies.append(Dependency(name: substructure.name, properties: substructure.properties))
                 }

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
@@ -114,12 +114,21 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
             }
     }
 
-    /// The name of the expression call types in this structure.
-    var expressionCallNames: [String] {
-        return filterSubstructure(by: "source.lang.swift.expr.call", recursively: true)
+    /// The unique set of expression call types in this structure.
+    var uniqueExpressionCallNames: [String] {
+        let allNames = filterSubstructure(by: "source.lang.swift.expr.call", recursively: true)
             .map { (item: [String: SourceKitRepresentable]) -> String in
                 item.name
+            }
+        var set = Set<String>()
+        var uniqueNames = [String]()
+        for name in allNames {
+            if !set.contains(name) {
+                set.insert(name)
+                uniqueNames.append(name)
+            }
         }
+        return uniqueNames
     }
 
     /// The name of the inherited types of this structure.

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
@@ -121,6 +121,7 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
                 item.name
             }
         var set = Set<String>()
+        // Use a separate array instead of directly using the Set to preserve ordering.
         var uniqueNames = [String]()
         for name in allNames {
             if !set.contains(name) {

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
@@ -120,16 +120,8 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
             .map { (item: [String: SourceKitRepresentable]) -> String in
                 item.name
             }
-        var set = Set<String>()
-        // Use a separate array instead of directly using the Set to preserve ordering.
-        var uniqueNames = [String]()
-        for name in allNames {
-            if !set.contains(name) {
-                set.insert(name)
-                uniqueNames.append(name)
-            }
-        }
-        return uniqueNames
+        let set = Set<String>(allNames)
+        return Array(set).sorted()
     }
 
     /// The name of the inherited types of this structure.

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -29,6 +29,10 @@ class MyComponent: NeedleFoundation.Component<MyDependency> {
     var myChildComponent: MyChildComponent {
         return MyChildComponent(parent: self)
     }
+
+    func childComponent(with dynamicDependency: String) -> MyChildComponent {
+        return MyChildComponent(parent: self, dynamicDependency: dynamicDependency)
+    }
 }
 
 protocol SomeNonCoreDependency: Dependency {

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ASTParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ASTParserTaskTests.swift
@@ -54,7 +54,7 @@ class ASTParserTaskTests: AbstractParserTests {
         let myComponent = node.components.first { (component: ASTComponent) -> Bool in
             component.name == "MyComponent"
         }!
-        XCTAssertEqual(myComponent.expressionCallTypeNames, ["Stream", "Donut", "shared", "MyChildComponent", "Basket"])
+        XCTAssertEqual(myComponent.expressionCallTypeNames, ["Basket", "Donut", "MyChildComponent", "Stream", "shared"])
         XCTAssertEqual(myComponent.name, "MyComponent")
         XCTAssertEqual(myComponent.dependencyProtocolName, "MyDependency")
         XCTAssertEqual(myComponent.properties.count, 4)
@@ -78,7 +78,7 @@ class ASTParserTaskTests: AbstractParserTests {
         let my2Component = node.components.first { (component: ASTComponent) -> Bool in
             component.name == "My2Component"
         }!
-        XCTAssertEqual(my2Component.expressionCallTypeNames, ["shared", "Wallet", "Banana", "Apple", "Book"])
+        XCTAssertEqual(my2Component.expressionCallTypeNames, ["Apple", "Banana", "Book", "Wallet", "shared"])
         XCTAssertEqual(my2Component.name, "My2Component")
         XCTAssertEqual(my2Component.dependencyProtocolName, "My2Dependency")
         XCTAssertEqual(my2Component.properties.count, 2)

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedASTParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedASTParserTaskTests.swift
@@ -39,7 +39,7 @@ class PluginizedASTParserTaskTests: AbstractParserTests {
         let myComponent = node.components.first { (component: ASTComponent) -> Bool in
             component.name == "MyComponent"
         }!
-        XCTAssertEqual(myComponent.expressionCallTypeNames, ["Stream", "Donut", "shared", "MyChildComponent", "Basket"])
+        XCTAssertEqual(myComponent.expressionCallTypeNames, ["Basket", "Donut", "MyChildComponent", "Stream", "shared"])
         XCTAssertEqual(myComponent.name, "MyComponent")
         XCTAssertEqual(myComponent.dependencyProtocolName, "MyDependency")
         XCTAssertEqual(myComponent.properties.count, 4)
@@ -63,7 +63,7 @@ class PluginizedASTParserTaskTests: AbstractParserTests {
         let my2Component = node.components.first { (component: ASTComponent) -> Bool in
             component.name == "My2Component"
         }!
-        XCTAssertEqual(my2Component.expressionCallTypeNames, ["shared", "Wallet", "Banana", "Apple", "Book"])
+        XCTAssertEqual(my2Component.expressionCallTypeNames, ["Apple", "Banana", "Book", "Wallet", "shared"])
         XCTAssertEqual(my2Component.name, "My2Component")
         XCTAssertEqual(my2Component.dependencyProtocolName, "My2Dependency")
         XCTAssertEqual(my2Component.properties.count, 2)
@@ -81,7 +81,7 @@ class PluginizedASTParserTaskTests: AbstractParserTests {
         let someNonCoreComponent = node.nonCoreComponents.first { (component: ASTComponent) -> Bool in
             component.name == "SomeNonCoreComponent"
         }!
-        XCTAssertEqual(someNonCoreComponent.expressionCallTypeNames, ["NonCoreObject", "shared", "SharedObject"])
+        XCTAssertEqual(someNonCoreComponent.expressionCallTypeNames, ["NonCoreObject", "SharedObject", "shared"])
         XCTAssertEqual(someNonCoreComponent.name, "SomeNonCoreComponent")
         XCTAssertEqual(someNonCoreComponent.dependencyProtocolName, "SomeNonCoreDependency")
         XCTAssertEqual(someNonCoreComponent.properties.count, 2)

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/Game/GameComponent.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/Game/GameComponent.swift
@@ -42,6 +42,22 @@ class GameComponent: PluginizedComponent<GameDependency, GamePluginExtension, Ga
     var mutableScoreStream: MutableScoreStream {
         return ScoreStreamImpl()
     }
+
+    let dynamicDependency: String
+
+    override init(parent: ComponentType) {
+        // Normally if we have a dynamic dependency, this constructor would not exist.
+        // This fake value is just to get the code to compile for demonstration of
+        // dynamic dependencies.
+        self.dynamicDependency = ""
+        super.init(parent: parent)
+    }
+
+    // Dynamic dependency constructor. Dynamic dependency provided by parent scope.
+    init(parent: ComponentType, dynamicDependency: String) {
+        self.dynamicDependency = dynamicDependency
+        super.init(parent: parent)
+    }
 }
 
 // Use a builder protocol to allow mocking for unit tests. At the same time,

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/LoggedIn/LoggedInComponent.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/LoggedIn/LoggedInComponent.swift
@@ -39,6 +39,13 @@ class LoggedInComponent: PluginizedComponent<EmptyDependency, LoggedInPluginExte
     var gameComponent: GameComponent {
         return GameComponent(parent: self)
 	}
+
+    // This demonstrates how to inject dynamic dependency into a child scope
+    // as well as providing a unit test case for invoking the same child
+    // scope constructor twice without generating duplicate code.
+    func gameComponent(with dynamicDependency: String) -> GameComponent {
+        return GameComponent(parent: self, dynamicDependency: dynamicDependency)
+    }
 }
 
 // Use a builder protocol to allow mocking for unit tests. At the same time,


### PR DESCRIPTION
This avoids generating duplicate providers.

Fixes #151