### PR TITLE
Add support for multiple source directories

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
@@ -29,11 +29,11 @@ enum DependencyGraphParserError: Error {
 /// outputs the dependency graph.
 class DependencyGraphParser {
 
-    /// Parse all the Swift sources within the directory of given URL,
+    /// Parse all the Swift sources within the directories of given URLs,
     /// excluding any file that contains a suffix specified in the given
     /// exclusion list. Parsing sources concurrently using the given executor.
     ///
-    /// - parameter rootUrl: The URL of the directory to scan from.
+    /// - parameter rootUrls: The URLs of the directories to scan from.
     /// - parameter exclusionSuffixes: If a file name contains a suffix
     /// in this list, the said file is excluded from parsing.
     /// - parameter executor: The executor to use for concurrent processing
@@ -42,23 +42,25 @@ class DependencyGraphParser {
     /// statements.
     /// - throws: `DependencyGraphParserError.timeout` if parsing a Swift
     /// source timed out.
-    func parse(from rootUrl: URL, excludingFilesWith exclusionSuffixes: [String] = [], using executor: SequenceExecutor) throws -> (components: [Component], imports: [String]) {
-        let urlHandles: [UrlSequenceHandle] = enqueueParsingTasks(with: rootUrl, excludingFilesWith: exclusionSuffixes, using: executor)
+    func parse(from rootUrls: [URL], excludingFilesWith exclusionSuffixes: [String] = [], using executor: SequenceExecutor) throws -> (components: [Component], imports: [String]) {
+        let urlHandles: [UrlSequenceHandle] = enqueueParsingTasks(with: rootUrls, excludingFilesWith: exclusionSuffixes, using: executor)
         let (components, dependencies, imports) = try collectDataModels(with: urlHandles)
         return process(components, dependencies, imports)
     }
 
     // MARK: - Private
 
-    private func enqueueParsingTasks(with rootUrl: URL, excludingFilesWith exclusionSuffixes: [String], using executor: SequenceExecutor) -> [(SequenceExecutionHandle<DependencyGraphNode>, URL)] {
+    private func enqueueParsingTasks(with rootUrls: [URL], excludingFilesWith exclusionSuffixes: [String], using executor: SequenceExecutor) -> [(SequenceExecutionHandle<DependencyGraphNode>, URL)] {
         var taskHandleTuples = [(handle: SequenceExecutionHandle<DependencyGraphNode>, fileUrl: URL)]()
 
         // Enumerate all files and execute parsing sequences concurrently.
         let enumerator = FileEnumerator()
-        enumerator.enumerate(from: rootUrl) { (fileUrl: URL) in
-            let task = FileFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes)
-            let taskHandle = executor.executeSequence(from: task, with: nextExecution(after:with:))
-            taskHandleTuples.append((taskHandle, fileUrl))
+        for url in rootUrls {
+            enumerator.enumerate(from: url) { (fileUrl: URL) in
+                let task = FileFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes)
+                let taskHandle = executor.executeSequence(from: task, with: nextExecution(after:with:))
+                taskHandleTuples.append((taskHandle, fileUrl))
+            }
         }
 
         return taskHandleTuples

--- a/Generator/Sources/NeedleFramework/Pluginized/PluginizedNeedle.swift
+++ b/Generator/Sources/NeedleFramework/Pluginized/PluginizedNeedle.swift
@@ -20,20 +20,21 @@ import Foundation
 /// The entry point to Needle, providing all the functionalities of the system.
 public class PluginizedNeedle {
 
-    /// Parse Swift source files by recurively scanning the directories starting
-    /// from the specified source path, excluding files with specified suffixes.
-    /// Generate the necessary dependency provider code and export to the
-    /// specified destination path.
+    /// Parse Swift source files by recurively scanning the given directories
+    /// excluding files with specified suffixes. Generate the necessary
+    /// dependency provider code and export to the specified destination path.
     ///
-    /// - parameter sourceRootPath: The root directory of source files to parse.
+    /// - parameter sourceRootPaths: The directories of source files to parse.
     /// - parameter exclusionSuffixes: The file suffixes to exclude from parsing.
     /// - parameter additionalImports: The additional import statements to add
     /// to the ones parsed from source files.
     /// - parameter headerDocPath: The path to custom header doc file to be
     /// included at the top of the generated file.
     /// - parameter destinationPath: The path to export generated code to.
-    public static func generate(from sourceRootPath: String, excludingFilesWith exclusionSuffixes: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String) {
-        let sourceRootUrl = URL(fileURLWithPath: sourceRootPath)
+    public static func generate(from sourceRootPaths: [String], excludingFilesWith exclusionSuffixes: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String) {
+        let sourceRootUrls = sourceRootPaths.map { (path: String) -> URL in
+            URL(fileURLWithPath: path)
+        }
         #if DEBUG
             let executor: SequenceExecutor = ProcessInfo().environment["SINGLE_THREADED"] != nil ? SerialSequenceExecutor() : ConcurrentSequenceExecutor(name: "PluginizedNeedle.generate", qos: .userInteractive)
         #else
@@ -41,7 +42,7 @@ public class PluginizedNeedle {
         #endif
         let parser = PluginizedDependencyGraphParser()
         do {
-            let (components, pluginizedComponents, imports) = try parser.parse(from: sourceRootUrl, excludingFilesWith: exclusionSuffixes, using: executor)
+            let (components, pluginizedComponents, imports) = try parser.parse(from: sourceRootUrls, excludingFilesWith: exclusionSuffixes, using: executor)
             let exporter = PluginizedDependencyGraphExporter()
             try exporter.export(components, pluginizedComponents, with: imports + additionalImports, to: destinationPath, using: executor, include: headerDocPath)
         } catch DependencyGraphParserError.timeout(let sourcePath) {

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -29,8 +29,8 @@ class GenerateCommand: Command {
     let name = "generate"
 
     private let overview = "Generate DI code based on all Swift source files in a directory."
-    private let sourceRootPath: PositionalArgument<String>
     private let destinationPath: PositionalArgument<String>
+    private let sourceRootPaths: PositionalArgument<[String]>
     private let suffixes: OptionArgument<[String]>
     private let additionalImports: OptionArgument<[String]>
     private let scanPlugins: OptionArgument<Bool>
@@ -38,8 +38,8 @@ class GenerateCommand: Command {
 
     required init(parser: ArgumentParser) {
         let subparser = parser.add(subparser: name, overview: overview)
-        sourceRootPath = subparser.add(positional: "sourceRootPath", kind: String.self, usage: "Path to the root folder of Swift source files.", completion: .filename)
         destinationPath = subparser.add(positional: "destinationPath", kind: String.self, usage: "Path to the destination file of generated Swift DI code.", completion: .filename)
+        sourceRootPaths = subparser.add(positional: "sourceRootPaths", kind: [String].self, strategy: ArrayParsingStrategy.upToNextOption, usage: "Path to the root folder of Swift source files.", completion: .filename)
         suffixes = subparser.add(option: "--suffixes", shortName: "-sfx", kind: [String].self, usage: "Filename suffix(es) without extensions to exclude from parsing.", completion: .filename)
         scanPlugins = subparser.add(option: "--pluginized", shortName: "-p", kind: Bool.self, usage: "Whether or not to consider plugins when parsing.")
         additionalImports = subparser.add(option: "--additional-imports", shortName: "-ai", kind: [String].self, usage: "Additional modules to import in the generated file, in addition to the ones parsed from source files.", completion: .none)
@@ -47,22 +47,22 @@ class GenerateCommand: Command {
     }
 
     func execute(with arguments: ArgumentParser.Result) {
-        if let sourceRootPath = arguments.get(sourceRootPath) {
-            if let destinationPath = arguments.get(destinationPath) {
+        if let destinationPath = arguments.get(destinationPath) {
+            if let sourceRootPaths = arguments.get(sourceRootPaths) {
                 let suffixes = arguments.get(self.suffixes) ?? []
                 let additionalImports = arguments.get(self.additionalImports) ?? []
                 let scanPlugins = arguments.get(self.scanPlugins) ?? false
                 let headerDocPath = arguments.get(self.headerDocPath) ?? nil
                 if scanPlugins {
-                    PluginizedNeedle.generate(from: sourceRootPath, excludingFilesWith: suffixes, with: additionalImports, headerDocPath, to: destinationPath)
+                    PluginizedNeedle.generate(from: sourceRootPaths, excludingFilesWith: suffixes, with: additionalImports, headerDocPath, to: destinationPath)
                 } else {
-                    Needle.generate(from: sourceRootPath, excludingFilesWith: suffixes, with: additionalImports, headerDocPath, to: destinationPath)
+                    Needle.generate(from: sourceRootPaths, excludingFilesWith: suffixes, with: additionalImports, headerDocPath, to: destinationPath)
                 }
             } else {
-                fatalError("Missing destination path.")
+                fatalError("Missing source files root directories.")
             }
         } else {
-            fatalError("Missing source files root directory.")
+            fatalError("Missing destination path.")
         }
     }
 }

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -39,7 +39,7 @@ class GenerateCommand: Command {
     required init(parser: ArgumentParser) {
         let subparser = parser.add(subparser: name, overview: overview)
         destinationPath = subparser.add(positional: "destinationPath", kind: String.self, usage: "Path to the destination file of generated Swift DI code.", completion: .filename)
-        sourceRootPaths = subparser.add(positional: "sourceRootPaths", kind: [String].self, strategy: ArrayParsingStrategy.upToNextOption, usage: "Path to the root folder of Swift source files.", completion: .filename)
+        sourceRootPaths = subparser.add(positional: "sourceRootPaths", kind: [String].self, strategy: ArrayParsingStrategy.upToNextOption, usage: "Paths to the root folders of Swift source files.", completion: .filename)
         suffixes = subparser.add(option: "--suffixes", shortName: "-sfx", kind: [String].self, usage: "Filename suffix(es) without extensions to exclude from parsing.", completion: .filename)
         scanPlugins = subparser.add(option: "--pluginized", shortName: "-p", kind: Bool.self, usage: "Whether or not to consider plugins when parsing.")
         additionalImports = subparser.add(option: "--additional-imports", shortName: "-ai", kind: [String].self, usage: "Additional modules to import in the generated file, in addition to the ones parsed from source files.", completion: .none)

--- a/Generator/Tests/NeedleFrameworkTests/Generating/AbstractGeneratorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/AbstractGeneratorTests.swift
@@ -30,7 +30,7 @@ class AbstractGeneratorTests: XCTestCase {
         let executor = MockSequenceExecutor()
 
         do {
-            return try parser.parse(from: fixturesURL, excludingFilesWith: ["ha", "yay", "blah"], using: executor)
+            return try parser.parse(from: [fixturesURL], excludingFilesWith: ["ha", "yay", "blah"], using: executor)
         } catch {
             fatalError("\(error)")
         }

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/AbstractPluginizedGeneratorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/AbstractPluginizedGeneratorTests.swift
@@ -31,7 +31,7 @@ class AbstractPluginizedGeneratorTests: XCTestCase {
         let executor = MockSequenceExecutor()
 
         do {
-            return try parser.parse(from: fixturesURL, excludingFilesWith: ["ha", "yay", "blah"], using: executor)
+            return try parser.parse(from: [fixturesURL], excludingFilesWith: ["ha", "yay", "blah"], using: executor)
         } catch {
             fatalError("\(error)")
         }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
@@ -50,7 +50,7 @@ class DependencyGraphParserTests: AbstractParserTests {
         XCTAssertEqual(executor.executeCallCount, 0)
 
         do {
-            _ = try parser.parse(from: fixturesURL, excludingFilesWith: ["ha", "yay", "blah"], using: executor)
+            _ = try parser.parse(from: [fixturesURL], excludingFilesWith: ["ha", "yay", "blah"], using: executor)
         } catch {
             XCTFail("\(error)")
         }
@@ -72,7 +72,7 @@ class DependencyGraphParserTests: AbstractParserTests {
         XCTAssertEqual(executor.executeCallCount, 0)
 
         do {
-            let (components, imports) = try parser.parse(from: fixturesURL, excludingFilesWith: ["ha", "yay", "blah"], using: executor)
+            let (components, imports) = try parser.parse(from: [fixturesURL], excludingFilesWith: ["ha", "yay", "blah"], using: executor)
             let childComponent = components.filter { $0.name == "MyChildComponent" }.first!
             let parentComponent = components.filter { $0.name == "MyComponent" }.first!
             XCTAssertTrue(childComponent.parents.first! == parentComponent)

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
@@ -50,7 +50,7 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
         XCTAssertEqual(executor.executeCallCount, 0)
 
         do {
-            _ = try parser.parse(from: fixturesURL, excludingFilesWith: ["ha", "yay", "blah"], using: executor)
+            _ = try parser.parse(from: [fixturesURL], excludingFilesWith: ["ha", "yay", "blah"], using: executor)
         } catch {
             XCTFail("\(error)")
         }
@@ -72,7 +72,7 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
         XCTAssertEqual(executor.executeCallCount, 0)
 
         do {
-            let (components, pluginizedComponents, imports) = try parser.parse(from: fixturesURL, excludingFilesWith: ["ha", "yay", "blah"], using: executor)
+            let (components, pluginizedComponents, imports) = try parser.parse(from: [fixturesURL], excludingFilesWith: ["ha", "yay", "blah"], using: executor)
             let childComponent = components.filter { $0.name == "MyChildComponent" }.first!
             let parentComponent = components.filter { $0.name == "MyComponent" }.first!
             XCTAssertTrue(childComponent.parents.first! == parentComponent)


### PR DESCRIPTION
Some projects have multiple root source directories to parse, yet specifying the higher level ancestor directory would lead to too many noise files. This adds the support to specify multiple source directories to parse.