### PR TITLE
Add minimum logging output level

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
@@ -104,7 +104,7 @@ extension Dictionary where Key: ExpressibleByStringLiteral {
                     let isPrivate = (accessibility == "source.lang.swift.accessibility.private")
                     let isFilePrivate = (accessibility == "source.lang.swift.accessibility.fileprivate")
                     if isPrivate || isFilePrivate {
-                        warning("\(self.name) (\(propertyItem.property.name): \(propertyItem.property.type)) property is \(isPrivate ? "private" : "fileprivate"), therefore inaccessible on DI graph.")
+                        info("\(self.name) (\(propertyItem.property.name): \(propertyItem.property.type)) property is \(isPrivate ? "private" : "fileprivate"), therefore inaccessible on DI graph.")
                         return nil
                     } else {
                         return propertyItem.property

--- a/Generator/Sources/NeedleFramework/Utilities/Logger.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/Logger.swift
@@ -14,18 +14,90 @@
 //  limitations under the License.
 //
 
+import Concurrency
 import Foundation
 
-/// Log the given warning message.
+/// The various levels of logging.
+public enum LoggingLevel: Int {
+    /// The most verbose level including all logs.
+    case debug
+    /// The level that includes everything except debug logs.
+    case info
+    /// The level that only includes warning logs.
+    case warning
+
+    /// An cute emoticon describing the log level.
+    public var emoticon: String {
+        switch self {
+        case .debug: return "🐞"
+        case .info: return "📋"
+        case .warning: return "❗️"
+        }
+    }
+
+    /// Retrieve the logging level based on the given String value.
+    ///
+    /// - parameter value: The `String` value to parse from.
+    /// - returns: The corresponding `LoggingLevel` if there is one.
+    /// `nil` otherwise.
+    public static func level(from value: String) -> LoggingLevel? {
+        switch value {
+        case "debug": return .debug
+        case "info": return .info
+        case "warning": return .warning
+        default: return nil
+        }
+    }
+}
+
+// Use `AtomicInt` since logging may be invoked from multiple threads.
+private let minLoggingOutputLevel = AtomicInt(initialValue: LoggingLevel.warning.rawValue)
+
+/// Set the minimum logging level required to output a message.
+///
+/// - parameter minLoggingOutputLevel: The minimum logging level.
+public func set(minLoggingOutputLevel level: LoggingLevel) {
+    minLoggingOutputLevel.value = level.rawValue
+}
+
+/// Log the given message at the `debug` level.
 ///
 /// - parameter message: The message to log.
-public func warning(_ message: String) {
-    #if DEBUG
-        UnitTestLogger.instance.log(message)
-    #else
-        print(message)
-    #endif
+/// - note: The mesasge is only logged if the current `minLoggingOutputLevel`
+/// is set at or below the `debug` level.
+public func debug(_ message: String) {
+    log(message, atLevel: .debug)
 }
+
+/// Log the given message at the `info` level.
+///
+/// - parameter message: The message to log.
+/// - note: The mesasge is only logged if the current `minLoggingOutputLevel`
+/// is set at or below the `info` level.
+public func info(_ message: String) {
+    log(message, atLevel: .info)
+}
+
+/// Log the given message at the `warning` level.
+///
+/// - parameter message: The message to log.
+/// - note: The mesasge is only logged if the current `minLoggingOutputLevel`
+/// is set at or below the `warning` level.
+public func warning(_ message: String) {
+    log(message, atLevel: .warning)
+}
+
+private func log(_ message: String, atLevel level: LoggingLevel) {
+    #if DEBUG
+        UnitTestLogger.instance.log(message, at: level)
+    #endif
+
+    if level.rawValue >= minLoggingOutputLevel.value {
+        print("\(level.emoticon) \(message)")
+    }
+}
+
+// MARK: - Unit Test
 
 /// A logger that accumulates log messages to support unit testing.
 class UnitTestLogger {
@@ -44,8 +116,7 @@ class UnitTestLogger {
 
     private init() {}
 
-    fileprivate func log(_ message: String) {
-        print(message)
+    fileprivate func log(_ message: String, at level: LoggingLevel) {
         lockedMessages.append(message)
     }
 }

--- a/Generator/Sources/needle/AbstractCommand.swift
+++ b/Generator/Sources/needle/AbstractCommand.swift
@@ -1,0 +1,59 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import NeedleFramework
+import Utility
+
+/// The base class of all commands that perform a set of logic common
+/// to all commands.
+class AbstractCommand: Command {
+    /// The name used to check if this command should be executed.
+    let name: String
+
+    /// Initializer.
+    ///
+    /// - parameter name: The name used to check if this command should
+    /// be executed.
+    /// - parameter overview: The overview description of this command.
+    /// - parameter parser: The argument parser to use.
+    init(name: String, overview: String, parser: ArgumentParser) {
+        self.name = name
+        let subparser = parser.add(subparser: name, overview: overview)
+        setupArguments(with: subparser)
+    }
+
+    /// Setup the arguments using the given parser.
+    ///
+    /// - parameter parser: The argument parser to use.
+    func setupArguments(with parser: ArgumentParser) {
+        loggingLevel = parser.add(option: "--logging-level", shortName: "-lv", kind: String.self, usage: "The logging level to use.")
+    }
+
+    /// Execute the command.
+    ///
+    /// - parameter arguments: The command line arguments to execute the
+    /// command with.
+    func execute(with arguments: ArgumentParser.Result) {
+        if let loggingLevelArg = arguments.get(loggingLevel), let loggingLevel = LoggingLevel.level(from: loggingLevelArg) {
+            set(minLoggingOutputLevel: loggingLevel)
+        }
+    }
+
+    // MARK: - Private
+
+    private var loggingLevel: OptionArgument<String>!
+}

--- a/Generator/Sources/needle/Command.swift
+++ b/Generator/Sources/needle/Command.swift
@@ -17,13 +17,15 @@
 import Foundation
 import Utility
 
-/// Each available command for needle (needle <command> <params>) has a
-/// name that is used to decide which subparser to use by main().
+/// A specific Needle instruction to be executed based on a set of input
+/// arguments.
 protocol Command {
-    /// Name used to check which of the Commands to apply.
+    /// Name used to check if this command should be executed.
     var name: String { get }
-    /// Initializer, sets up the command-line flags.
-    init(parser: ArgumentParser)
+
     /// Execute the command.
+    ///
+    /// - parameter arguments: The command line arguments to execute the
+    /// command with.
     func execute(with arguments: ArgumentParser.Result)
 }

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -23,30 +23,36 @@ import Utility
 /// specified source path, excluding files with specified suffixes. It then
 /// generates the necessary dependency provider code and export to the specified
 /// destination path.
-class GenerateCommand: Command {
+class GenerateCommand: AbstractCommand {
 
-    /// The name of the command.
-    let name = "generate"
-
-    private let overview = "Generate DI code based on all Swift source files in a directory."
-    private let destinationPath: PositionalArgument<String>
-    private let sourceRootPaths: PositionalArgument<[String]>
-    private let suffixes: OptionArgument<[String]>
-    private let additionalImports: OptionArgument<[String]>
-    private let scanPlugins: OptionArgument<Bool>
-    private let headerDocPath: OptionArgument<String>
-
-    required init(parser: ArgumentParser) {
-        let subparser = parser.add(subparser: name, overview: overview)
-        destinationPath = subparser.add(positional: "destinationPath", kind: String.self, usage: "Path to the destination file of generated Swift DI code.", completion: .filename)
-        sourceRootPaths = subparser.add(positional: "sourceRootPaths", kind: [String].self, strategy: ArrayParsingStrategy.upToNextOption, usage: "Paths to the root folders of Swift source files.", completion: .filename)
-        suffixes = subparser.add(option: "--suffixes", shortName: "-sfx", kind: [String].self, usage: "Filename suffix(es) without extensions to exclude from parsing.", completion: .filename)
-        scanPlugins = subparser.add(option: "--pluginized", shortName: "-p", kind: Bool.self, usage: "Whether or not to consider plugins when parsing.")
-        additionalImports = subparser.add(option: "--additional-imports", shortName: "-ai", kind: [String].self, usage: "Additional modules to import in the generated file, in addition to the ones parsed from source files.", completion: .none)
-        headerDocPath = subparser.add(option: "--header-doc", shortName: "-hd", kind: String.self, usage: "Path to custom header doc file to be included at the top of the generated file.", completion: .filename)
+    /// Initializer.
+    ///
+    /// - parameter parser: The argument parser to use.
+    init(parser: ArgumentParser) {
+        super.init(name: "generate", overview: "Generate DI code based on all Swift source files in a directory.", parser: parser)
     }
 
-    func execute(with arguments: ArgumentParser.Result) {
+    /// Setup the arguments using the given parser.
+    ///
+    /// - parameter parser: The argument parser to use.
+    override func setupArguments(with parser: ArgumentParser) {
+        super.setupArguments(with: parser)
+
+        destinationPath = parser.add(positional: "destinationPath", kind: String.self, usage: "Path to the destination file of generated Swift DI code.", completion: .filename)
+        sourceRootPaths = parser.add(positional: "sourceRootPaths", kind: [String].self, strategy: ArrayParsingStrategy.upToNextOption, usage: "Paths to the root folders of Swift source files.", completion: .filename)
+        suffixes = parser.add(option: "--suffixes", shortName: "-sfx", kind: [String].self, usage: "Filename suffix(es) without extensions to exclude from parsing.", completion: .filename)
+        scanPlugins = parser.add(option: "--pluginized", shortName: "-p", kind: Bool.self, usage: "Whether or not to consider plugins when parsing.")
+        additionalImports = parser.add(option: "--additional-imports", shortName: "-ai", kind: [String].self, usage: "Additional modules to import in the generated file, in addition to the ones parsed from source files.", completion: .none)
+        headerDocPath = parser.add(option: "--header-doc", shortName: "-hd", kind: String.self, usage: "Path to custom header doc file to be included at the top of the generated file.", completion: .filename)
+    }
+
+    /// Execute the command.
+    ///
+    /// - parameter arguments: The command line arguments to execute the
+    /// command with.
+    override func execute(with arguments: ArgumentParser.Result) {
+        super.execute(with: arguments)
+
         if let destinationPath = arguments.get(destinationPath) {
             if let sourceRootPaths = arguments.get(sourceRootPaths) {
                 let suffixes = arguments.get(self.suffixes) ?? []
@@ -65,4 +71,13 @@ class GenerateCommand: Command {
             fatalError("Missing destination path.")
         }
     }
+
+    // MARK: - Private
+
+    private var destinationPath: PositionalArgument<String>!
+    private var sourceRootPaths: PositionalArgument<[String]>!
+    private var suffixes: OptionArgument<[String]>!
+    private var additionalImports: OptionArgument<[String]>!
+    private var scanPlugins: OptionArgument<Bool>!
+    private var headerDocPath: OptionArgument<String>!
 }

--- a/Generator/Sources/needle/main.swift
+++ b/Generator/Sources/needle/main.swift
@@ -21,22 +21,31 @@ import Utility
 
 func main() {
     let parser = ArgumentParser(usage: "<subcommand> <options>", overview: "Needle DI code generator.")
-    let commandsTypes: [Command.Type] = [GenerateCommand.self]
-    let commands = commandsTypes.map { $0.init(parser: parser) }
+    let commands = initializeCommands(with: parser)
     let inputs = Array(CommandLine.arguments.dropFirst())
     do {
         let args = try parser.parse(inputs)
-        if let subparserName = args.subparser(parser) {
-            for command in commands {
-                if subparserName == command.name {
-                    command.execute(with: args)
-                }
-            }
-        } else {
-            parser.printUsage(on: stdoutStream)
-        }
+        execute(commands, with: parser, args)
     } catch {
-        warning("Command-line pasing error (use --help for help): \(error)")
+        fatalError("Command-line pasing error (use --help for help): \(error)")
+    }
+}
+
+private func initializeCommands(with parser: ArgumentParser) -> [Command] {
+    return [
+        GenerateCommand(parser: parser)
+    ]
+}
+
+private func execute(_ commands: [Command], with parser: ArgumentParser, _ args: ArgumentParser.Result) {
+    if let subparserName = args.subparser(parser) {
+        for command in commands {
+            if subparserName == command.name {
+                command.execute(with: args)
+            }
+        }
+    } else {
+        parser.printUsage(on: stdoutStream)
     }
 }
 


### PR DESCRIPTION
Also updated `Command` structure to support a base `AbstractCommand` class which performs the common command logic. In this case, the common logic is setting minimum logging output level.

Fixes #154