### PR TITLE
Fixing travis CI test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,18 @@ matrix:
 
       script:
         - set -o pipefail
-        - cd Sample
+        - cd Sample/MVC
         - carthage update --platform iOS
         - cd TicTacToe
         - xcodebuild -version
         - xcodebuild -showsdks
         - instruments -s devices
         - xcodebuild -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Release clean build | xcpretty -c;
+        - xcodebuild -scheme "TicTacToe" -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Debug clean build test | xcpretty -c;
+	- cd ../../Pluginized
+	- carthage update --platform iOS
+	- cd TicTacToe
+	- xcodebuild -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Release clean build | xcpretty -c;
         - xcodebuild -scheme "TicTacToe" -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Debug clean build test | xcpretty -c;
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
 
       script:
         - set -o pipefail
+        - gem install xcpretty
         - cd Sample/MVC
         - carthage update --platform iOS
         - cd TicTacToe

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
         - instruments -s devices
         - xcodebuild -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Release clean build | xcpretty -c;
         - xcodebuild -scheme "TicTacToe" -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Debug clean build test | xcpretty -c;
-	- cd ../../Pluginized
-	- carthage update --platform iOS
-	- cd TicTacToe
-	- xcodebuild -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Release clean build | xcpretty -c;
+        - cd ../../Pluginized
+        - carthage update --platform iOS
+        - cd TicTacToe
+        - xcodebuild -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Release clean build | xcpretty -c;
         - xcodebuild -scheme "TicTacToe" -destination "OS=11.0,name=iPhone X" -sdk "$IOS_SDK" -configuration Debug clean build test | xcpretty -c;
 
 branches:


### PR DESCRIPTION
Noticed Travis CI builds were failing due to the Sample folder now having 2 TicTacToe projects. I have updated the test script to test both `MVC` and `Pluginized`.