### PR TITLE
Include DI branch path in error message

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
@@ -52,7 +52,7 @@ class DependencyProviderContentTask: AbstractTask<[ProcessedDependencyProvider]>
             do {
                 return try process(provider)
             } catch DependencyProviderContentError.propertyNotFound(let info) {
-                var message = "Could not find a provider for (\(info.name): \(info.type)) which was required by \(info.dependency), in the DI branch of \(provider.pathString)."
+                var message = "Could not find a provider for (\(info.name): \(info.type)) which was required by \(info.dependency), along the DI branch of \(provider.pathString)."
                 if let possibleMatchComponent = info.possibleMatchComponent {
                     message += " Found possible matches \(info.possibleNames) at \(possibleMatchComponent)."
                 }

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
@@ -52,7 +52,7 @@ class DependencyProviderContentTask: AbstractTask<[ProcessedDependencyProvider]>
             do {
                 return try process(provider)
             } catch DependencyProviderContentError.propertyNotFound(let info) {
-                var message = "Could not find a provider for \(info.name): \(info.type) which was required by \(info.dependency)."
+                var message = "Could not find a provider for (\(info.name): \(info.type)) which was required by \(info.dependency), in the DI branch of \(provider.pathString)."
                 if let possibleMatchComponent = info.possibleMatchComponent {
                     message += " Found possible matches \(info.possibleNames) at \(possibleMatchComponent)."
                 }

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
@@ -60,7 +60,7 @@ class PluginizedDependencyProviderContentTask: AbstractTask<[PluginizedProcessed
                     return try process(provider, withAuxillaryPropertiesFrom: pluginExtensionMap, auxillarySourceType: .pluginExtension)
                 }
             } catch DependencyProviderContentError.propertyNotFound(let info) {
-                var message = "Could not find a provider for (\(info.name): \(info.type)) which was required by \(info.dependency), in the DI branch of \(provider.pathString)."
+                var message = "Could not find a provider for (\(info.name): \(info.type)) which was required by \(info.dependency), along the DI branch of \(provider.pathString)."
                 if let possibleMatchComponent = info.possibleMatchComponent {
                     message += " Found possible matches \(info.possibleNames) at \(possibleMatchComponent)."
                 }

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
@@ -60,7 +60,7 @@ class PluginizedDependencyProviderContentTask: AbstractTask<[PluginizedProcessed
                     return try process(provider, withAuxillaryPropertiesFrom: pluginExtensionMap, auxillarySourceType: .pluginExtension)
                 }
             } catch DependencyProviderContentError.propertyNotFound(let info) {
-                var message = "Could not find a provider for \(info.name): \(info.type) which was required by \(info.dependency)."
+                var message = "Could not find a provider for (\(info.name): \(info.type)) which was required by \(info.dependency), in the DI branch of \(provider.pathString)."
                 if let possibleMatchComponent = info.possibleMatchComponent {
                     message += " Found possible matches \(info.possibleNames) at \(possibleMatchComponent)."
                 }


### PR DESCRIPTION
When a dependency is not fulfilled in a particular DI branch, also report out the branch's path for easier debugging.