### PR TITLE
Fix Xcode 10 caused shared optional dependency issue

### DIFF
--- a/Foundation/Sources/NeedleFoundation/Component.swift
+++ b/Foundation/Sources/NeedleFoundation/Component.swift
@@ -77,7 +77,11 @@ open class Component<DependencyType>: ComponentType {
             sharedInstanceLock.unlock()
         }
 
-        if let instance = sharedInstances[__function] as? T {
+        // Additional nil coalescing is needed to mitigate a Swift bug appearing in Xcode 10.
+        // see https://bugs.swift.org/browse/SR-8704.
+        // Without this measure, calling `shared` from a function that returns an optional type
+        // will always pass the check below and return nil if the instance is not initialized.
+        if let instance = (sharedInstances[__function] as? T?) ?? nil {
             return instance
         }
         let instance = factory()

--- a/Foundation/Tests/NeedleFoundationTests/ComponentTests.swift
+++ b/Foundation/Tests/NeedleFoundationTests/ComponentTests.swift
@@ -35,11 +35,19 @@ class ComponentTests: XCTestCase {
         XCTAssertTrue(component.share2 === component.share2)
         XCTAssertFalse(component.share === component.share2)
     }
+
+    func test_shared_optional() {
+        let component = TestComponent(parent: BootstrapComponent())
+        XCTAssert(component.optionalShare === component.expectedOptionalShare)
+    }
 }
 
 class TestComponent: Component<EmptyDependency> {
 
     fileprivate var callCount: Int = 0
+    fileprivate var expectedOptionalShare: ClassProtocol? = {
+        return ClassProtocolImpl()
+    }()
 
     var share: NSObject {
         callCount += 1
@@ -49,4 +57,16 @@ class TestComponent: Component<EmptyDependency> {
     var share2: NSObject {
         return shared { NSObject() }
     }
+
+    fileprivate var optionalShare: ClassProtocol? {
+        return shared { self.expectedOptionalShare }
+    }
+}
+
+private protocol ClassProtocol: AnyObject {
+
+}
+
+private class ClassProtocolImpl: ClassProtocol {
+
 }


### PR DESCRIPTION
With Xcode 10, Swift compiler has a bug (https://bugs.swift.org/browse/SR-8704), where optional dependencies are always returned as `nil`.