### PR TITLE
Track and report task ID when execution times out

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.20.0"),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
-        .package(url: "https://github.com/uber/swift-concurrency.git", from: "0.5.4"),
+        .package(url: "https://github.com/uber/swift-concurrency.git", from: "0.6.0"),
     ],
     targets: [
         .target(

--- a/Generator/README.md
+++ b/Generator/README.md
@@ -4,10 +4,10 @@
 
 ### Compiling from source:
 
-First fetch the dependencies:
+First resolve the dependencies:
 
 ```
-$ swift package fetch
+$ swift package resolve
 ```
 
 You can then build from the command-line:

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
@@ -41,6 +41,7 @@ class DependencyProviderContentTask: AbstractTask<[ProcessedDependencyProvider]>
     /// - parameter providers: The list of providers that we need to fill in
     init(providers: [DependencyProvider]) {
         self.providers = providers
+        super.init(id: TaskIds.dependencyProviderContentTask.rawValue)
     }
 
     /// Execute the task and returns the processed in-memory dependency graph

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderDeclarerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderDeclarerTask.swift
@@ -27,6 +27,7 @@ class DependencyProviderDeclarerTask: AbstractTask<[DependencyProvider]> {
     /// provider.
     init(component: Component) {
         self.component = component
+        super.init(id: TaskIds.dependencyProviderDeclarerTask.rawValue)
     }
 
     /// Execute the task and returns the in-memory dependency graph data models.

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
@@ -26,6 +26,7 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
     /// - parameter providers: The processed dependency provider to serialize.
     init(providers: [ProcessedDependencyProvider]) {
         self.providers = providers
+        super.init(id: TaskIds.dependencyProviderSerializerTask.rawValue)
     }
 
     /// Execute the task and returns the in-memory serialized dependency

--- a/Generator/Sources/NeedleFramework/Generating/FileContentLoaderTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/FileContentLoaderTask.swift
@@ -26,6 +26,7 @@ class FileContentLoaderTask: AbstractTask<String> {
     /// - parameter filePath: The path to the file to be loaded.
     init(filePath: String) {
         self.filePath = filePath
+        super.init(id: TaskIds.fileContentLoaderTask.rawValue)
     }
 
     /// Execute the task and returns the file content.

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionSerializerTask.swift
@@ -27,6 +27,7 @@ class PluginExtensionSerializerTask : AbstractTask<SerializedProvider> {
     /// plugin extension provider.
     init(component: PluginizedComponent) {
         self.component = component
+        super.init(id: TaskIds.pluginExtensionSerializerTask.rawValue)
     }
 
     /// Execute the task and returns the data model.

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
@@ -45,6 +45,8 @@ class PluginizedDependencyProviderContentTask: AbstractTask<[PluginizedProcessed
         self.nonCoreComponentMap = nonCoreComponentMap
         self.pluginExtensionMap = pluginExtensionMap
         self.auxilarySourceParentDependency = auxilarySourceParentDependency
+
+        super.init(id: TaskIds.pluginizedDependencyProviderContentTask.rawValue)
     }
 
     /// Execute the task and returns the processed in-memory dependency graph

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
@@ -27,6 +27,7 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
     /// to serialize.
     init(providers: [PluginizedProcessedDependencyProvider]) {
         self.providers = providers
+        super.init(id: TaskIds.pluginizedDependencyProviderSerializerTask.rawValue)
     }
 
     /// Execute the task and returns the in-memory serialized dependency

--- a/Generator/Sources/NeedleFramework/Needle.swift
+++ b/Generator/Sources/NeedleFramework/Needle.swift
@@ -42,22 +42,28 @@ public class Needle {
     /// - parameter headerDocPath: The path to custom header doc file to be
     /// included at the top of the generated file.
     /// - parameter destinationPath: The path to export generated code to.
-    public static func generate(from sourceRootPaths: [String], withSourcesListFormat sourcesListFormatValue: String? = nil, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String) {
+    /// - parameter shouldTackTaskId: `true` if task IDs should be tracked
+    /// as tasks are executed. `false` otherwise. By tracking the task IDs,
+    /// if waiting on the completion of a task sequence times out, the
+    /// reported error contains the ID of the task that was being executed
+    /// when the timeout occurred. The tracking does incur a minor
+    /// performance cost. This value defaults to `false`.
+    public static func generate(from sourceRootPaths: [String], withSourcesListFormat sourcesListFormatValue: String? = nil, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, shouldTackTaskId: Bool) {
         let sourceRootUrls = sourceRootPaths.map { (path: String) -> URL in
             URL(path: path)
         }
         #if DEBUG
-            let executor: SequenceExecutor = ProcessInfo().environment["SINGLE_THREADED"] != nil ? SerialSequenceExecutor() : ConcurrentSequenceExecutor(name: "Needle.generate", qos: .userInteractive)
+            let executor: SequenceExecutor = ProcessInfo().environment["SINGLE_THREADED"] != nil ? SerialSequenceExecutor() : ConcurrentSequenceExecutor(name: "Needle.generate", qos: .userInteractive, shouldTackTaskId: shouldTackTaskId)
         #else
-            let executor = ConcurrentSequenceExecutor(name: "Needle.generate", qos: .userInteractive)
+            let executor = ConcurrentSequenceExecutor(name: "Needle.generate", qos: .userInteractive, shouldTackTaskId: shouldTackTaskId)
         #endif
         let parser = DependencyGraphParser()
         do {
             let (components, imports) = try parser.parse(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor)
             let exporter = DependencyGraphExporter()
             try exporter.export(components, with: imports + additionalImports, to: destinationPath, using: executor, include: headerDocPath)
-        } catch DependencyGraphParserError.timeout(let sourcePath) {
-            fatalError("Parsing Swift source file at \(sourcePath) timed out.")
+        } catch DependencyGraphParserError.timeout(let sourcePath, let taskId) {
+            fatalError("Parsing Swift source file at \(sourcePath) timed out when executing task with ID \(taskId).")
         } catch DependencyGraphExporterError.timeout(let componentName) {
             fatalError("Generating dependency provider for \(componentName) timed out.")
         } catch DependencyGraphExporterError.unableToWriteFile(let outputFile) {

--- a/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
@@ -20,8 +20,10 @@ import Foundation
 /// Errors that can occur during parsing of the dependency graph from
 /// Swift sources.
 enum DependencyGraphParserError: Error {
-    /// Parsing a particular source file timed out.
-    case timeout(String)
+    /// Parsing a particular source file timed out. The associated values
+    /// are the path of the file being parsed and the ID of the task that
+    /// was being executed when the timeout occurred.
+    case timeout(String, Int)
 }
 
 /// The entry utility for the parsing phase. The parser deeply scans a
@@ -116,8 +118,8 @@ class DependencyGraphParser {
                 for statement in node.imports {
                     imports.insert(statement)
                 }
-            } catch SequenceExecutionError.awaitTimeout {
-                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString)
+            } catch SequenceExecutionError.awaitTimeout(let taskId) {
+                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
             } catch {
                 fatalError("Unhandled task execution error \(error)")
             }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
@@ -115,8 +115,8 @@ class PluginizedDependencyGraphParser {
                 for statement in node.imports {
                     imports.insert(statement)
                 }
-            } catch SequenceExecutionError.awaitTimeout {
-                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString)
+            } catch SequenceExecutionError.awaitTimeout(let taskId) {
+                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
             } catch {
                 fatalError("Unhandled task execution error \(error)")
             }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
@@ -27,6 +27,7 @@ class PluginizedASTParserTask: AbstractTask<PluginizedDependencyGraphNode> {
     /// - parameter ast: The AST of the file to parse.
     init(ast: AST) {
         self.ast = ast
+        super.init(id: TaskIds.pluginizedASTParserTask.rawValue)
     }
 
     /// Execute the task and returns the dependency graph data model.

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedFileFilterTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedFileFilterTask.swift
@@ -36,6 +36,7 @@ class PluginizedFileFilterTask: AbstractTask<FilterResult> {
         self.url = url
         self.exclusionSuffixes = exclusionSuffixes
         self.exclusionPaths = exclusionPaths
+        super.init(id: TaskIds.pluginizedFileFilterTask.rawValue)
     }
 
     /// Execute the task and returns the filter result indicating if the file

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
@@ -26,6 +26,7 @@ class ASTParserTask: AbstractTask<DependencyGraphNode> {
     /// - parameter ast: The AST of the file to parse.
     init(ast: AST) {
         self.ast = ast
+        super.init(id: TaskIds.astParserTask.rawValue)
     }
 
     /// Execute the task and returns the dependency graph data model.

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTProducerTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTProducerTask.swift
@@ -29,6 +29,7 @@ class ASTProducerTask: AbstractTask<AST> {
     init(sourceUrl: URL, sourceContent: String) {
         self.sourceUrl = sourceUrl
         self.sourceContent = sourceContent
+        super.init(id: TaskIds.astProducerTask.rawValue)
     }
 
     /// Execute the task and return the AST structure data model.

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/FileFilterTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/FileFilterTask.swift
@@ -42,6 +42,7 @@ class FileFilterTask: AbstractTask<FilterResult> {
         self.url = url
         self.exclusionSuffixes = exclusionSuffixes
         self.exclusionPaths = exclusionPaths
+        super.init(id: TaskIds.fileFilterTask.rawValue)
     }
 
     /// Execute the task and returns the filter result indicating if the file

--- a/Generator/Sources/NeedleFramework/Utilities/TaskIds.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/TaskIds.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-/// A list of IDs of tasks used in the generator.
+/// A list of IDs of task types used in the generator.
 enum TaskIds: Int {
     /// File filtering task IDs.
     case fileFilterTask = 1

--- a/Generator/Sources/NeedleFramework/Utilities/TaskIds.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/TaskIds.swift
@@ -1,0 +1,41 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A list of IDs of tasks used in the generator.
+enum TaskIds: Int {
+    /// File filtering task IDs.
+    case fileFilterTask = 1
+    case pluginizedFileFilterTask = 2
+    /// File content loading task ID.
+    case fileContentLoaderTask = 3
+    /// AST producing task ID.
+    case astProducerTask = 4
+    /// AST parsing task IDs.
+    case astParserTask = 5
+    case pluginizedASTParserTask = 6
+    /// Dependency provider declaring task ID.
+    case dependencyProviderDeclarerTask = 7
+    /// Dependency provider content task IDs.
+    case dependencyProviderContentTask = 8
+    case pluginizedDependencyProviderContentTask = 9
+    /// Dependency provider serialization task IDs.
+    case dependencyProviderSerializerTask = 10
+    case pluginizedDependencyProviderSerializerTask = 11
+    /// Plugin extension serialization task ID.
+    case pluginExtensionSerializerTask = 12
+}

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -46,6 +46,7 @@ class GenerateCommand: AbstractCommand {
         scanPlugins = parser.add(option: "--pluginized", shortName: "-p", kind: Bool.self, usage: "Whether or not to consider plugins when parsing.")
         additionalImports = parser.add(option: "--additional-imports", shortName: "-ai", kind: [String].self, usage: "Additional modules to import in the generated file, in addition to the ones parsed from source files.", completion: .none)
         headerDocPath = parser.add(option: "--header-doc", shortName: "-hd", kind: String.self, usage: "Path to custom header doc file to be included at the top of the generated file.", completion: .filename)
+        shouldTackTaskId = parser.add(option: "--track-task", shortName: "-tt", kind: Bool.self, usage: "Whether or not to track task IDs.")
     }
 
     /// Execute the command.
@@ -63,10 +64,11 @@ class GenerateCommand: AbstractCommand {
                 let additionalImports = arguments.get(self.additionalImports) ?? []
                 let scanPlugins = arguments.get(self.scanPlugins) ?? false
                 let headerDocPath = arguments.get(self.headerDocPath) ?? nil
+                let shouldTackTaskId = arguments.get(self.shouldTackTaskId) ?? false
                 if scanPlugins {
-                    PluginizedNeedle.generate(from: sourceRootPaths, withSourcesListFormat: sourcesListFormat, excludingFilesEndingWith: excludeSuffixes, excludingFilesWithPaths: excludePaths, with: additionalImports, headerDocPath, to: destinationPath)
+                    PluginizedNeedle.generate(from: sourceRootPaths, withSourcesListFormat: sourcesListFormat, excludingFilesEndingWith: excludeSuffixes, excludingFilesWithPaths: excludePaths, with: additionalImports, headerDocPath, to: destinationPath, shouldTackTaskId: shouldTackTaskId)
                 } else {
-                    Needle.generate(from: sourceRootPaths, withSourcesListFormat: sourcesListFormat, excludingFilesEndingWith: excludeSuffixes, excludingFilesWithPaths: excludePaths, with: additionalImports, headerDocPath, to: destinationPath)
+                    Needle.generate(from: sourceRootPaths, withSourcesListFormat: sourcesListFormat, excludingFilesEndingWith: excludeSuffixes, excludingFilesWithPaths: excludePaths, with: additionalImports, headerDocPath, to: destinationPath, shouldTackTaskId: shouldTackTaskId)
                 }
             } else {
                 fatalError("Missing source files root directories.")
@@ -86,4 +88,5 @@ class GenerateCommand: AbstractCommand {
     private var additionalImports: OptionArgument<[String]>!
     private var scanPlugins: OptionArgument<Bool>!
     private var headerDocPath: OptionArgument<String>!
+    private var shouldTackTaskId: OptionArgument<Bool>!
 }


### PR DESCRIPTION
When a timeout occurs while waiting for a sequence of tasks to finish execution, it is useful to understand which task was executing when the timeout occurred.