### PR TITLE
Better encapsulation of some of the SourceKit concepts

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
@@ -50,19 +50,17 @@ class PluginizedASTParserTask: AbstractTask<PluginizedDependencyGraphNode> {
         var pluginExtensions = [PluginExtension]()
 
         let substructures = ast.structure.substructures
-        for item in substructures {
-            if let substructure = item as? [String: SourceKitRepresentable] {
-                if substructure.isPluginizedComponent {
-                    let (dependencyProtocolName, pluginExtensionName, nonCoreComponentName) = substructure.pluginizedGenerics
-                    let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
-                    pluginizedComponents.append(PluginizedASTComponent(data: component, pluginExtensionType: pluginExtensionName, nonCoreComponentType: nonCoreComponentName))
-                } else if substructure.isNonCoreComponent {
-                    let dependencyProtocolName = substructure.dependencyProtocolName(for: "NonCoreComponent")
-                    let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
-                    nonCoreComponents.append(component)
-                } else if substructure.isPluginExtension {
-                    pluginExtensions.append(PluginExtension(name: substructure.name, properties: substructure.properties))
-                }
+        for substructure in substructures {
+            if substructure.isPluginizedComponent {
+                let (dependencyProtocolName, pluginExtensionName, nonCoreComponentName) = substructure.pluginizedGenerics
+                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
+                pluginizedComponents.append(PluginizedASTComponent(data: component, pluginExtensionType: pluginExtensionName, nonCoreComponentType: nonCoreComponentName))
+            } else if substructure.isNonCoreComponent {
+                let dependencyProtocolName = substructure.dependencyProtocolName(for: "NonCoreComponent")
+                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
+                nonCoreComponents.append(component)
+            } else if substructure.isPluginExtension {
+                pluginExtensions.append(PluginExtension(name: substructure.name, properties: substructure.properties))
             }
         }
 
@@ -71,6 +69,24 @@ class PluginizedASTParserTask: AbstractTask<PluginizedDependencyGraphNode> {
 }
 
 // MARK: - SourceKit AST Parsing Utilities
+
+extension Structure {
+    var isPluginizedComponent: Bool {
+        return dictionary.isPluginizedComponent
+    }
+
+    var isNonCoreComponent: Bool {
+        return dictionary.isNonCoreComponent
+    }
+
+    var isPluginExtension: Bool {
+        return dictionary.isPluginExtension
+    }
+
+    var pluginizedGenerics: (dependencyProtocolName: String, pluginExtensionName: String, nonCoreComponentName: String) {
+        return dictionary.pluginizedGenerics
+    }
+}
 
 private extension Dictionary where Key: ExpressibleByStringLiteral {
 

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
@@ -16,7 +16,6 @@
 
 import Concurrency
 import Foundation
-import SourceKittenFramework
 
 /// A task that parses Swift AST into dependency graph data models.
 class ASTParserTask: AbstractTask<DependencyGraphNode> {
@@ -46,14 +45,12 @@ class ASTParserTask: AbstractTask<DependencyGraphNode> {
         var dependencies = [Dependency]()
 
         let substructures = ast.structure.substructures
-        for item in substructures {
-            if let substructure = item as? [String: SourceKitRepresentable] {
-                if substructure.isComponent {
-                    let dependencyProtocolName = substructure.dependencyProtocolName(for: "Component")
-                    components.append(ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames))
-                } else if substructure.isDependencyProtocol {
-                    dependencies.append(Dependency(name: substructure.name, properties: substructure.properties))
-                }
+        for substructure in substructures {
+            if substructure.isComponent {
+                let dependencyProtocolName = substructure.dependencyProtocolName(for: "Component")
+                components.append(ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: substructure.properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames))
+            } else if substructure.isDependencyProtocol {
+                dependencies.append(Dependency(name: substructure.name, properties: substructure.properties))
             }
         }
         return (components, dependencies)

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
@@ -22,8 +22,41 @@ import SourceKittenFramework
 extension Structure {
 
     /// The substructures of this structure.
-    var substructures: [SourceKitRepresentable] {
-        return (dictionary["key.substructure"]  as? [SourceKitRepresentable]) ?? []
+    var substructures: [Structure] {
+        let substructures = (dictionary["key.substructure"]  as? [SourceKitRepresentable]) ?? []
+
+        let result = substructures.compactMap { (substructure: SourceKitRepresentable) -> Structure? in
+            if let structure = substructure as? [String: SourceKitRepresentable] {
+                return Structure(sourceKitResponse: structure)
+            } else {
+                return nil
+            }
+        }
+        return result
+    }
+
+    var isComponent: Bool {
+        return dictionary.isComponent
+    }
+
+    var isDependencyProtocol: Bool {
+        return dictionary.isDependencyProtocol
+    }
+
+    var name: String {
+        return dictionary.name
+    }
+
+    func dependencyProtocolName(for componentType: String) -> String {
+        return dictionary.dependencyProtocolName(for: componentType)
+    }
+
+    var properties: [Property] {
+        return dictionary.properties
+    }
+
+    var uniqueExpressionCallNames: [String] {
+        return dictionary.uniqueExpressionCallNames
     }
 }
 


### PR DESCRIPTION
- Specifically, only AST utils needs to understand what a `SourceKitRepresentable` is.