### PR TITLE
Kill SourceKitService process before retry parsing

### DIFF
--- a/Generator/README.md
+++ b/Generator/README.md
@@ -7,7 +7,7 @@
 First resolve the dependencies:
 
 ```
-$ swift package resolve
+$ swift package update
 ```
 
 You can then build from the command-line:

--- a/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
@@ -21,10 +21,9 @@ import Foundation
 /// Swift sources.
 enum DependencyGraphParserError: Error {
     /// Parsing a particular source file timed out. The associated values
-    /// are the path of the file being parsed, the ID of the task that
-    /// was being executed when the timeout occurred, and if the sourcekit
-    /// process was running when the timeout occurred.
-    case timeout(String, Int, Bool)
+    /// are the path of the file being parsed and the ID of the task that
+    /// was being executed when the timeout occurred.
+    case timeout(String, Int)
 }
 
 /// The entry utility for the parsing phase. The parser deeply scans a
@@ -122,7 +121,7 @@ class DependencyGraphParser {
                     imports.insert(statement)
                 }
             } catch SequenceExecutionError.awaitTimeout(let taskId) {
-                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId, isSourceKitRunning)
+                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
             } catch {
                 fatalError("Unhandled task execution error \(error)")
             }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
@@ -118,7 +118,7 @@ class PluginizedDependencyGraphParser {
                     imports.insert(statement)
                 }
             } catch SequenceExecutionError.awaitTimeout(let taskId) {
-                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId, isSourceKitRunning)
+                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
             } catch {
                 fatalError("Unhandled task execution error \(error)")
             }

--- a/Generator/Sources/NeedleFramework/Utilities/SourceKitUtilities.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/SourceKitUtilities.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A set of utility functions for the SourceKitService.
+public protocol SourceKitUtilities {
+    /// Check if the sourcekit daemon process is running by searching through
+    /// all processes without ttys.
+    var isSourceKitRunning: Bool { get }
+
+    /// Issue the initialize command to the SourceKit service.
+    func initialize()
+
+    /// Kill the SourceKitService process.
+    ///
+    /// - note: This method does not use the `shutdown` supported by the
+    /// actual SourceKit service. Instead it kills the entire process.
+    /// - returns: `true` if killing the process succeeded. `false otherwise.
+    func killProcess() -> Bool
+}
+
+/// A set of utility functions for the SourceKitService.
+public class SourceKitUtilitiesImpl: SourceKitUtilities {
+    
+    /// Initializer.
+    ///
+    /// - parameter processUtilities: The process utilities to use.
+    public init(processUtilities: ProcessUtilities) {
+        self.processUtilities = processUtilities
+    }
+
+    /// Check if the sourcekit daemon process is running by searching through
+    /// all processes without ttys.
+    public var isSourceKitRunning: Bool {
+        let result = processUtilities.currentNonControllingTTYSProcesses
+        // These process names are found in library_wrapper_sourcekitd.swift
+        // of SourceKittenFramework.
+        return result.contains("libsourcekitdInProc") || result.contains("sourcekitd.framework")
+    }
+
+    /// Issue the initialize command to the SourceKit service.
+    public func initialize() {
+        sourcekitd_initialize()
+    }
+    
+    /// Kill the SourceKitService process.
+    ///
+    /// - note: This method does not use the `shutdown` supported by the
+    /// actual SourceKit service. Instead it kills the entire process.
+    /// - returns: `true` if killing the process succeeded. `false otherwise.
+    public func killProcess() -> Bool {
+        return processUtilities.killAll("SourceKitService")
+    }
+    
+    // MARK: - Private
+    
+    private let processUtilities: ProcessUtilities
+}

--- a/Generator/Sources/NeedleFramework/Utilities/SourceKittenFramework/library_wrapper.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/SourceKittenFramework/library_wrapper.swift
@@ -1,0 +1,232 @@
+//  Copied from SourceKittenFramework library_wrapper.swift [https://github.com/jpsim/SourceKitten/blob/master/Source/SourceKittenFramework/library_wrapper.swift]
+//
+//  library_wrapper.swift
+//  sourcekitten
+//
+//  Created by Norio Nomura on 2/20/16.
+//  Copyright © 2016 SourceKitten. All rights reserved.
+//
+
+import Foundation
+
+struct DynamicLinkLibrary {
+    let path: String
+    let handle: UnsafeMutableRawPointer
+
+    func load<T>(symbol: String) -> T {
+        if let sym = dlsym(handle, symbol) {
+            return unsafeBitCast(sym, to: T.self)
+        }
+        let errorString = String(validatingUTF8: dlerror())
+        fatalError("Finding symbol \(symbol) failed: \(errorString ?? "unknown error")")
+    }
+}
+
+#if os(Linux)
+let toolchainLoader = Loader(searchPaths: [
+    linuxSourceKitLibPath,
+    linuxFindSwiftenvActiveLibPath,
+    linuxFindSwiftInstallationLibPath,
+    linuxDefaultLibPath
+].compactMap({ $0 }))
+#else
+let toolchainLoader = Loader(searchPaths: [
+    xcodeDefaultToolchainOverride,
+    toolchainDir,
+    xcrunFindPath,
+    /*
+    These search paths are used when `xcode-select -p` points to
+    "Command Line Tools OS X for Xcode", but Xcode.app exists.
+    */
+    applicationsDir?.xcodeDeveloperDir.toolchainDir,
+    applicationsDir?.xcodeBetaDeveloperDir.toolchainDir,
+    userApplicationsDir?.xcodeDeveloperDir.toolchainDir,
+    userApplicationsDir?.xcodeBetaDeveloperDir.toolchainDir
+].compactMap { path in
+    if let fullPath = path?.usrLibDir, fullPath.isFile {
+        return fullPath
+    }
+    return nil
+})
+#endif
+
+struct Loader {
+    let searchPaths: [String]
+
+    func load(path: String) -> DynamicLinkLibrary {
+        let fullPaths = searchPaths.map { $0.appending(pathComponent: path) }.filter { $0.isFile }
+
+        // try all fullPaths that contains target file,
+        // then try loading with simple path that depends resolving to DYLD
+        for fullPath in fullPaths + [path] {
+            if let handle = dlopen(fullPath, RTLD_LAZY) {
+                return DynamicLinkLibrary(path: path, handle: handle)
+            }
+        }
+
+        fatalError("Loading \(path) failed")
+    }
+}
+
+private func env(_ name: String) -> String? {
+    return ProcessInfo.processInfo.environment[name]
+}
+
+/// Run a process at the given (absolute) path, capture output, return outupt.
+private func runCommand(_ path: String, _ args: String...) -> String? {
+    let process = Process()
+    process.launchPath = path
+    process.arguments = args
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.launch()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard let encoded = String(data: data, encoding: String.Encoding.utf8) else {
+        return nil
+    }
+
+    let trimmed = encoded.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+    if trimmed.isEmpty {
+        return nil
+    }
+    return trimmed
+}
+
+/// Returns "LINUX_SOURCEKIT_LIB_PATH" environment variable.
+internal let linuxSourceKitLibPath = env("LINUX_SOURCEKIT_LIB_PATH")
+
+/// If available, uses `swiftenv` to determine the user's active Swift root.
+internal let linuxFindSwiftenvActiveLibPath: String? = {
+    guard let swiftenvPath = runCommand("/usr/bin/which", "swiftenv") else {
+        return nil
+    }
+
+    guard let swiftenvRoot = runCommand(swiftenvPath, "prefix") else {
+        return nil
+    }
+
+    return swiftenvRoot + "/usr/lib"
+}()
+
+/// Attempts to discover the location of libsourcekitdInProc.so by looking at
+/// the `swift` binary on the path.
+internal let linuxFindSwiftInstallationLibPath: String? = {
+    guard let swiftPath = runCommand("/usr/bin/which", "swift") else {
+        return nil
+    }
+
+    if linuxSourceKitLibPath == nil && linuxFindSwiftenvActiveLibPath == nil &&
+       swiftPath.hasSuffix("/shims/swift") {
+        /// If we hit this path, the user is invoking Swift via swiftenv shims and has not set the
+        /// environment variable; this means we're going to end up trying to load from `/usr/lib`
+        /// which will fail - and instead, we can give a more useful error message.
+        fatalError("Swift is installed via swiftenv but swiftenv is not initialized.")
+    }
+
+    if !swiftPath.hasSuffix("/bin/swift") {
+        return nil
+    }
+
+    /// .../bin/swift -> .../lib
+    return swiftPath.deleting(lastPathComponents: 2).appending(pathComponent: "/lib")
+}()
+
+/// Fallback path on Linux if no better option is available.
+internal let linuxDefaultLibPath = "/usr/lib"
+
+/// Returns "XCODE_DEFAULT_TOOLCHAIN_OVERRIDE" environment variable
+///
+/// `launch-with-toolchain` sets the toolchain path to the
+/// "XCODE_DEFAULT_TOOLCHAIN_OVERRIDE" environment variable.
+private let xcodeDefaultToolchainOverride = env("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")
+
+/// Returns "TOOLCHAIN_DIR" environment variable
+///
+/// `Xcode`/`xcodebuild` sets the toolchain path to the
+/// "TOOLCHAIN_DIR" environment variable.
+private let toolchainDir = env("TOOLCHAIN_DIR")
+
+/// Returns toolchain directory that parsed from result of `xcrun -find swift`
+///
+/// This is affected by "DEVELOPER_DIR", "TOOLCHAINS" environment variables.
+private let xcrunFindPath: String? = {
+    let pathOfXcrun = "/usr/bin/xcrun"
+
+    if !FileManager.default.isExecutableFile(atPath: pathOfXcrun) {
+        return nil
+    }
+
+    let task = Process()
+    task.launchPath = pathOfXcrun
+    task.arguments = ["-find", "swift"]
+
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    task.launch() // if xcode-select does not exist, crash with `NSInvalidArgumentException`.
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let output = String(data: data, encoding: .utf8) else {
+        return nil
+    }
+
+    var start = output.startIndex
+    var end = output.startIndex
+    var contentsEnd = output.startIndex
+    output.getLineStart(&start, end: &end, contentsEnd: &contentsEnd, for: start..<start)
+    let xcrunFindSwiftPath = String(output[start..<contentsEnd])
+    guard xcrunFindSwiftPath.hasSuffix("/usr/bin/swift") else {
+        return nil
+    }
+    let xcrunFindPath = xcrunFindSwiftPath.deleting(lastPathComponents: 3)
+    // Return nil if xcrunFindPath points to "Command Line Tools OS X for Xcode"
+    // because it doesn't contain `sourcekitd.framework`.
+    if xcrunFindPath == "/Library/Developer/CommandLineTools" {
+        return nil
+    }
+    return xcrunFindPath
+}()
+
+private let applicationsDir: String? =
+    NSSearchPathForDirectoriesInDomains(.applicationDirectory, .systemDomainMask, true).first
+
+private let userApplicationsDir: String? =
+    NSSearchPathForDirectoriesInDomains(.applicationDirectory, .userDomainMask, true).first
+
+private extension String {
+    var toolchainDir: String {
+        return appending(pathComponent: "Toolchains/XcodeDefault.xctoolchain")
+    }
+
+    var xcodeDeveloperDir: String {
+        return appending(pathComponent: "Xcode.app/Contents/Developer")
+    }
+
+    var xcodeBetaDeveloperDir: String {
+        return appending(pathComponent: "Xcode-beta.app/Contents/Developer")
+    }
+
+    var usrLibDir: String {
+        return appending(pathComponent: "/usr/lib")
+    }
+
+    func appending(pathComponent: String) -> String {
+        return URL(fileURLWithPath: self).appendingPathComponent(pathComponent).path
+    }
+
+    func deleting(lastPathComponents numberOfPathComponents: Int) -> String {
+        var url = URL(fileURLWithPath: self)
+        for _ in 0..<numberOfPathComponents {
+            url = url.deletingLastPathComponent()
+        }
+        return url.path
+    }
+}
+
+extension String {
+    internal var isFile: Bool {
+        return FileManager.default.fileExists(atPath: self)
+    }
+}

--- a/Generator/Sources/NeedleFramework/Utilities/SourceKittenFramework/library_wrapper_sourcekitd.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/SourceKittenFramework/library_wrapper_sourcekitd.swift
@@ -1,0 +1,16 @@
+//  Copied from SourceKittenFramework library_wrapper.swift [https://github.com/jpsim/SourceKitten/blob/master/Source/SourceKittenFramework/library_wrapper_sourcekitd.swift]
+//
+//  library_wrapper.swift
+//  sourcekitten
+//
+//  Created by Norio Nomura on 2/20/16.
+//  Copyright © 2016 SourceKitten. All rights reserved.
+//
+
+#if os(Linux)
+private let path = "libsourcekitdInProc.so"
+#else
+private let path = "sourcekitd.framework/Versions/A/sourcekitd"
+#endif
+private let library = toolchainLoader.load(path: path)
+internal let sourcekitd_initialize: @convention(c) () -> () = library.load(symbol: "sourcekitd_initialize")

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -74,7 +74,8 @@ class GenerateCommand: AbstractCommand {
                 let parsingTimeout = arguments.get(self.parsingTimeout, withDefault: defaultTimeout)
                 let exportingTimeout = arguments.get(self.exportingTimeout, withDefault: defaultTimeout)
                 let retryParsingOnTimeoutLimit = arguments.get(self.retryParsingOnTimeoutLimit) ?? 0
-                let generator: Generator = scanPlugins ? PluginizedGenerator() : Generator()
+                let sourceKitUtilities = SourceKitUtilitiesImpl(processUtilities: ProcessUtilitiesImpl())
+                let generator: Generator = scanPlugins ? PluginizedGenerator(sourceKitUtilities: sourceKitUtilities) : Generator(sourceKitUtilities: sourceKitUtilities)
                 do {
                     try generator.generate(from: sourceRootPaths, withSourcesListFormat: sourcesListFormat, excludingFilesEndingWith: excludeSuffixes, excludingFilesWithPaths: excludePaths, with: additionalImports, headerDocPath, to: destinationPath, shouldCollectParsingInfo: shouldCollectParsingInfo, parsingTimeout: parsingTimeout, exportingTimeout: exportingTimeout, retryParsingOnTimeoutLimit: retryParsingOnTimeoutLimit)
                 } catch GeneratorError.withMessage(let message) {

--- a/Generator/Tests/NeedleFrameworkTests/Entry/GeneratorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Entry/GeneratorTests.swift
@@ -21,7 +21,8 @@ import XCTest
 class GeneratorTests: XCTestCase {
 
     func test_generate_noThrow_verifySingleCall() {
-        let generator = MockGenerator()
+        let sourceKitUtilities = MockSourceKitUtilities()
+        let generator = MockGenerator(sourceKitUtilities: sourceKitUtilities)
 
         XCTAssertEqual(generator.generateCallCount, 0)
 
@@ -31,12 +32,23 @@ class GeneratorTests: XCTestCase {
     }
 
     func test_generate_throwTimeoutError_withRetry_verifyRetry() {
-        let generator = MockGenerator()
+        let sourceKitUtilities = MockSourceKitUtilities()
+        sourceKitUtilities.isSourceKitRunningHandler =  {
+            return true
+        }
+        sourceKitUtilities.killProcessHandler =  {
+            return true
+        }
+
+        let generator = MockGenerator(sourceKitUtilities: sourceKitUtilities)
         generator.generateClosure = {
-            throw DependencyGraphParserError.timeout("", 123, true)
+            throw DependencyGraphParserError.timeout("", 123)
         }
 
         XCTAssertEqual(generator.generateCallCount, 0)
+        XCTAssertEqual(sourceKitUtilities.isSourceKitRunningCallCount, 0)
+        XCTAssertEqual(sourceKitUtilities.initializeCallCount, 0)
+        XCTAssertEqual(sourceKitUtilities.killProcessCallCount, 0)
 
         do {
             try generator.generate(from: [], excludingFilesEndingWith: [], excludingFilesWithPaths: [], with: [], nil, to: "blah", shouldCollectParsingInfo: true, parsingTimeout: 10, exportingTimeout: 10, retryParsingOnTimeoutLimit: 3)
@@ -46,12 +58,23 @@ class GeneratorTests: XCTestCase {
         }
 
         XCTAssertEqual(generator.generateCallCount, 3)
+        XCTAssertEqual(sourceKitUtilities.isSourceKitRunningCallCount, 3)
+        XCTAssertEqual(sourceKitUtilities.initializeCallCount, 2)
+        XCTAssertEqual(sourceKitUtilities.killProcessCallCount, 2)
     }
 
     func test_generate_throwTimeoutError_withNoRetry_verifySingleCall() {
-        let generator = MockGenerator()
+        let sourceKitUtilities = MockSourceKitUtilities()
+        sourceKitUtilities.isSourceKitRunningHandler =  {
+            return true
+        }
+        sourceKitUtilities.killProcessHandler =  {
+            return true
+        }
+
+        let generator = MockGenerator(sourceKitUtilities: sourceKitUtilities)
         generator.generateClosure = {
-            throw DependencyGraphParserError.timeout("", 123, true)
+            throw DependencyGraphParserError.timeout("", 123)
         }
 
         XCTAssertEqual(generator.generateCallCount, 0)
@@ -64,6 +87,9 @@ class GeneratorTests: XCTestCase {
         }
 
         XCTAssertEqual(generator.generateCallCount, 1)
+        XCTAssertEqual(sourceKitUtilities.isSourceKitRunningCallCount, 1)
+        XCTAssertEqual(sourceKitUtilities.initializeCallCount, 0)
+        XCTAssertEqual(sourceKitUtilities.killProcessCallCount, 0)
     }
 }
 
@@ -75,5 +101,42 @@ private class MockGenerator: Generator {
     override func generate(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, using executor: SequenceExecutor, withParsingTimeout parsingTimeout: Double, exportingTimeout: Double) throws {
         generateCallCount += 1
         try generateClosure?()
+    }
+}
+
+private class MockSourceKitUtilities: SourceKitUtilities {
+    
+    fileprivate var initializeHandler: (() -> ())?
+    fileprivate var initializeCallCount = 0
+    
+    fileprivate var killProcessHandler: (() -> Bool)?
+    fileprivate var killProcessCallCount = 0
+    
+    fileprivate var isSourceKitRunningHandler: (() -> Bool)?
+    fileprivate var isSourceKitRunningCallCount = 0
+    
+    var isSourceKitRunning: Bool {
+        isSourceKitRunningCallCount += 1
+        if let isSourceKitRunningHandler = isSourceKitRunningHandler {
+            return isSourceKitRunningHandler()
+        } else {
+            return false
+        }
+    }
+    
+    func initialize() {
+        initializeCallCount += 1
+        if let initializeHandler = initializeHandler {
+            initializeHandler()
+        }
+    }
+    
+    func killProcess() -> Bool {
+        killProcessCallCount += 1
+        if let killProcessHandler = killProcessHandler {
+            return killProcessHandler()
+        } else {
+            return false
+        }
     }
 }


### PR DESCRIPTION
When parsing times out, it is likely due to SourceKitService hanging. Simply retry again does not seem to resolve the issue. Instead this change force kills the SourceKit service process and re-initializes it. Since SourceKittenFramework does not expose SourceKit service initialization publicly, a couple of files are copied over. A separate PR for SourceKittenFramework will be created to expose the necessary methods.