### PR TITLE
Add version command

### DIFF
--- a/Generator/Sources/needle/Version.swift
+++ b/Generator/Sources/needle/Version.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+let version = "0.8.4"

--- a/Generator/Sources/needle/VersionCommand.swift
+++ b/Generator/Sources/needle/VersionCommand.swift
@@ -1,0 +1,38 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import NeedleFramework
+import Utility
+
+/// A command that returns the current version of the generator.
+class VersionCommand: AbstractCommand {
+
+    /// Initializer.
+    ///
+    /// - parameter parser: The argument parser to use.
+    init(parser: ArgumentParser) {
+        super.init(name: "version", overview: "The version of this generator.", parser: parser)
+    }
+
+    /// Execute the command.
+    ///
+    /// - parameter arguments: The command line arguments to execute the
+    /// command with.
+    override func execute(with arguments: ArgumentParser.Result) {
+        print(version)
+    }
+}

--- a/Generator/Sources/needle/main.swift
+++ b/Generator/Sources/needle/main.swift
@@ -33,6 +33,7 @@ func main() {
 
 private func initializeCommands(with parser: ArgumentParser) -> [Command] {
     return [
+        VersionCommand(parser: parser),
         GenerateCommand(parser: parser)
     ]
 }


### PR DESCRIPTION
As a "hacky" solution, the version number is declared as a Swift source file, since Swift Package Manager does not support including resource files.