### PR TITLE
Disable sandbox when building from Homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY_FOLDER_PREFIX?=/usr/local
 BINARY_FOLDER=$(BINARY_FOLDER_PREFIX)/bin/
 GENERATOR_FOLDER=Generator
-SWIFT_BUILD_FLAGS=-c release -Xswiftc -static-stdlib
+SWIFT_BUILD_FLAGS=--disable-sandbox -c release -Xswiftc -static-stdlib
 
 .PHONY: clean build install uninstall
 


### PR DESCRIPTION
According to @ilovezfs "Hi, I'm one of the Homebrew maintainers. You need to run swift build --disable-sandbox because Homebrew runs all builds in a sandbox, and you cannot exec another sandbox within a sandbox.

You should not run brew install --no-sandbox, which is intended for debugging purposes only."

The original issue where the quote is from is here https://github.com/yonaskolb/XcodeGen/issues/51