### PR TITLE
Uninstall before install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 build:
 	cd $(GENERATOR_FOLDER) && swift build $(SWIFT_BUILD_FLAGS)
 
-install: clean build
+install: uninstall clean build
 	install -d "$(BINARY_FOLDER)"
 	install "$(shell cd $(GENERATOR_FOLDER) && swift build $(SWIFT_BUILD_FLAGS) --show-bin-path)/needle" "$(BINARY_FOLDER)"
 


### PR DESCRIPTION
Technically this is necessary, since we can just run `brew link --overwrite needle`. However, this makes the `brew install` cleaner.