### PR TITLE
Update generator version to prepare for Homebrew publish

### DIFF
--- a/Generator/Sources/needle/Version.swift
+++ b/Generator/Sources/needle/Version.swift
@@ -14,4 +14,4 @@
 //  limitations under the License.
 //
 
-let version = "0.8.4"
+let version = "0.8.5"


### PR DESCRIPTION
Manually update this for now, since our Homebrew formula isn't published yet. We cannot use `make publish` until then. Otherwise the `brew bump-formula-pr` will fail.