### PR TITLE
Add concurrency limit parameter

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.20.0"),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
-        .package(url: "https://github.com/uber/swift-concurrency.git", from: "0.6.1"),
+        .package(url: "https://github.com/uber/swift-concurrency.git", from: "0.6.2"),
     ],
     targets: [
         .target(

--- a/Generator/Tests/NeedleFrameworkTests/Entry/GeneratorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Entry/GeneratorTests.swift
@@ -26,7 +26,7 @@ class GeneratorTests: XCTestCase {
 
         XCTAssertEqual(generator.generateCallCount, 0)
 
-        try! generator.generate(from: [], excludingFilesEndingWith: [], excludingFilesWithPaths: [], with: [], nil, to: "blah", shouldCollectParsingInfo: true, parsingTimeout: 10, exportingTimeout: 10, retryParsingOnTimeoutLimit: 1000)
+        try! generator.generate(from: [], excludingFilesEndingWith: [], excludingFilesWithPaths: [], with: [], nil, to: "blah", shouldCollectParsingInfo: true, parsingTimeout: 10, exportingTimeout: 10, retryParsingOnTimeoutLimit: 1000, concurrencyLimit: nil)
 
         XCTAssertEqual(generator.generateCallCount, 1)
     }
@@ -51,7 +51,7 @@ class GeneratorTests: XCTestCase {
         XCTAssertEqual(sourceKitUtilities.killProcessCallCount, 0)
 
         do {
-            try generator.generate(from: [], excludingFilesEndingWith: [], excludingFilesWithPaths: [], with: [], nil, to: "blah", shouldCollectParsingInfo: true, parsingTimeout: 10, exportingTimeout: 10, retryParsingOnTimeoutLimit: 3)
+            try generator.generate(from: [], excludingFilesEndingWith: [], excludingFilesWithPaths: [], with: [], nil, to: "blah", shouldCollectParsingInfo: true, parsingTimeout: 10, exportingTimeout: 10, retryParsingOnTimeoutLimit: 3, concurrencyLimit: nil)
             XCTFail()
         } catch {
             XCTAssertTrue(error is GeneratorError)
@@ -80,7 +80,7 @@ class GeneratorTests: XCTestCase {
         XCTAssertEqual(generator.generateCallCount, 0)
 
         do {
-            try generator.generate(from: [], excludingFilesEndingWith: [], excludingFilesWithPaths: [], with: [], nil, to: "blah", shouldCollectParsingInfo: true, parsingTimeout: 10, exportingTimeout: 10, retryParsingOnTimeoutLimit: 0)
+            try generator.generate(from: [], excludingFilesEndingWith: [], excludingFilesWithPaths: [], with: [], nil, to: "blah", shouldCollectParsingInfo: true, parsingTimeout: 10, exportingTimeout: 10, retryParsingOnTimeoutLimit: 0, concurrencyLimit: nil)
             XCTFail()
         } catch {
             XCTAssertTrue(error is GeneratorError)


### PR DESCRIPTION
Allows specifying a concurrent limit to ease SourceKitService load. A lower limit should prevent SourceKitService from hanging.

Also removed all the confusing short names for parameters.