### PR TITLE
Cycle detection for pluginized component with non-core component

### DIFF
--- a/Generator/Sources/NeedleFramework/Models/Property.swift
+++ b/Generator/Sources/NeedleFramework/Models/Property.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A data model representing a dependency property that is either provided by a
 /// `Component` or required by one.
-struct Property: Equatable {
+struct Property: Hashable {
     /// The variable name.
     let name: String
     /// The property type `String`.

--- a/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
@@ -134,7 +134,7 @@ class DependencyGraphParser {
             DuplicateValidator(components: components, dependencies: dependencies),
             ParentLinker(components: components),
             DependencyLinker(components: components, dependencies: dependencies),
-            CycleValidator(components: components)
+            AncestorCycleValidator(components: components)
         ]
         for processor in processors {
             do {

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
@@ -138,7 +138,8 @@ class PluginizedDependencyGraphParser {
             DependencyLinker(components: allComponents, dependencies: dependencies),
             NonCoreComponentLinker(pluginizedComponents: pluginizedComponents, nonCoreComponents: nonCoreComponents),
             PluginExtensionLinker(pluginizedComponents: pluginizedComponents, pluginExtensions: pluginExtensions),
-            CycleValidator(components: allComponents)
+            AncestorCycleValidator(components: allComponents),
+            PluginExtensionCycleValidator(pluginizedComponents: pluginizedComponents)
         ]
         for processor in processors {
             do {

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/PluginExtensionCycleValidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/PluginExtensionCycleValidator.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A post processing utility class that checks if there are any cycles
+/// in any of the pluginized components their plugin extensions.
+///
+/// - note: This validator requires all plugin extensions and non-core
+/// components have already been linked with their corresponding pluginized
+/// components.
+class PluginExtensionCycleValidator: Processor {
+
+    /// Initializer.
+    ///
+    /// - parameter pluginizedComponents: The list of pluginized components
+    /// to validate.
+    init(pluginizedComponents: [PluginizedASTComponent]) {
+        self.pluginizedComponents = pluginizedComponents
+    }
+
+    /// Process the data models.
+    ///
+    /// - throws: `ProcessingError` if any cycles are detected.
+    func process() throws {
+        for component in pluginizedComponents {
+            guard let pluginExtension = component.pluginExtension else {
+                throw ProcessingError.fail("\(component.data.name)'s plugin extension has not been linked.")
+            }
+            guard let nonCoreDependency = component.nonCoreComponent?.dependencyProtocol else {
+                throw ProcessingError.fail("\(component.data.name)'s non-core component dependency has not been linked.")
+            }
+
+            let nonCoreDepProperties = Set<Property>(nonCoreDependency.properties)
+            let pluginExtensionProperties = Set<Property>(pluginExtension.properties)
+            let componentProperties = Set<Property>(component.data.properties)
+            // This isn't an exact cycle matching, since we cannot check for
+            // how the property is provided by the core component. This just
+            // checks that core component provides a property which is also
+            // required by the plugin extension and the non-core component dependency.
+            // SourceKit does not provide the last bit of information, where the
+            // core component provides the property via `pluginExtension.property`.
+            // In this case, we are assuming the property is provided via the
+            // plugin extension, since it lists it, therefore causing a cycle.
+            let intersections = nonCoreDepProperties.intersection(pluginExtensionProperties).intersection(componentProperties)
+            if !intersections.isEmpty {
+                let cyclicPropertiesString = intersections
+                    .map { (property: Property) -> String in
+                        return "(\(property.name): \(property.type))"
+                    }
+                    .joined(separator: ", ")
+                throw ProcessingError.fail("\(component.data.name) contains cyclic plugin extension properties \(cyclicPropertiesString).")
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private let pluginizedComponents: [PluginizedASTComponent]
+}

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/AncestorCycleValidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/AncestorCycleValidator.swift
@@ -17,8 +17,8 @@
 import Foundation
 
 /// A post processing utility class that checks if there are any cycles
-/// in the dependency graph.
-class CycleValidator: Processor {
+/// in the dependency graph's ancestor paths.
+class AncestorCycleValidator: Processor {
 
     /// Initializer.
     ///
@@ -32,7 +32,7 @@ class CycleValidator: Processor {
     /// - throws: `ProcessingError` if any cycles are detected.
     func process() throws {
         for component in components {
-            if let cyclePath = findCycle(component, visitedComponents: []) {
+            if let cyclePath = findAncestorCycle(component, visitedComponents: []) {
                 let pathNames = cyclePath.map { (element: ASTComponent) -> String in
                     element.name
                 } + [component.name]
@@ -45,7 +45,7 @@ class CycleValidator: Processor {
 
     private let components: [ASTComponent]
 
-    private func findCycle(_ component: ASTComponent, visitedComponents: [ASTComponent]) -> [ASTComponent]? {
+    private func findAncestorCycle(_ component: ASTComponent, visitedComponents: [ASTComponent]) -> [ASTComponent]? {
         // Use DFS to detect cycles faster. Given the limited number of
         // elements, using a more complex algorithm like Tarjan's seems
         // unnecessary.
@@ -56,7 +56,7 @@ class CycleValidator: Processor {
             return visitedComponents
         } else {
             for ancestor in component.parents {
-                if let cyclePath = findCycle(ancestor, visitedComponents: visitedComponents + [component]) {
+                if let cyclePath = findAncestorCycle(ancestor, visitedComponents: visitedComponents + [component]) {
                     return cyclePath
                 }
             }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/AncestorCycleValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/AncestorCycleValidatorTests.swift
@@ -17,7 +17,7 @@
 import XCTest
 @testable import NeedleFramework
 
-class CycleValidatorTests: XCTestCase {
+class AncestorCycleValidatorTests: XCTestCase {
 
     func test_process_hasCycle() {
         let a = ASTComponent(name: "A", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
@@ -29,7 +29,7 @@ class CycleValidatorTests: XCTestCase {
         b.parents = [c, d]
         c.parents = [b]
 
-        let processor = CycleValidator(components: [a, b, c, d, m])
+        let processor = AncestorCycleValidator(components: [a, b, c, d, m])
         do {
             try processor.process()
             XCTFail()
@@ -47,7 +47,7 @@ class CycleValidatorTests: XCTestCase {
         b.parents = [c, d]
         c.parents = [m]
 
-        let processor = CycleValidator(components: [a, b, c, d, m])
+        let processor = AncestorCycleValidator(components: [a, b, c, d, m])
         do {
             try processor.process()
         } catch {

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionCycleValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionCycleValidatorTests.swift
@@ -1,0 +1,66 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import NeedleFramework
+
+class PluginExtensionCycleValidatorTests: AbstractPluginizedParserTests {
+
+    func test_process_withNoCycles_verifyNoError() {
+        let pluginExtension = PluginExtension(name: "PE", properties: [Property(name: "a", type: "A")])
+
+        let nonCoreDependency = Dependency(name: "NonCoreDep", properties: [Property(name: "b", type: "B")])
+        let nonCoreComponent = ASTComponent(name: "NonCoreComp", dependencyProtocolName: "NonCoreDep", properties: [Property(name: "c", type: "D")], expressionCallTypeNames: [])
+        nonCoreComponent.dependencyProtocol = nonCoreDependency
+
+        let coreComponent = ASTComponent(name: "CoreComp", dependencyProtocolName: "blah", properties: [Property(name: "e", type: "E")], expressionCallTypeNames: [])
+        let pluginizedComponent = PluginizedASTComponent(data: coreComponent, pluginExtensionType: "PE", nonCoreComponentType: "NonCoreComp")
+        pluginizedComponent.pluginExtension = pluginExtension
+        pluginizedComponent.nonCoreComponent = nonCoreComponent
+
+        let validator = PluginExtensionCycleValidator(pluginizedComponents: [pluginizedComponent])
+
+        do {
+            try validator.process()
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func test_process_withCycles_verifyThrowError() {
+        let pluginExtension = PluginExtension(name: "PE", properties: [Property(name: "a", type: "A")])
+
+        let nonCoreDependency = Dependency(name: "NonCoreDep", properties: [Property(name: "a", type: "A")])
+        let nonCoreComponent = ASTComponent(name: "NonCoreComp", dependencyProtocolName: "NonCoreDep", properties: [Property(name: "c", type: "D")], expressionCallTypeNames: [])
+        nonCoreComponent.dependencyProtocol = nonCoreDependency
+
+        let coreComponent = ASTComponent(name: "CoreComp", dependencyProtocolName: "blah", properties: [Property(name: "a", type: "A")], expressionCallTypeNames: [])
+        let pluginizedComponent = PluginizedASTComponent(data: coreComponent, pluginExtensionType: "PE", nonCoreComponentType: "NonCoreComp")
+        pluginizedComponent.pluginExtension = pluginExtension
+        pluginizedComponent.nonCoreComponent = nonCoreComponent
+
+        let validator = PluginExtensionCycleValidator(pluginizedComponents: [pluginizedComponent])
+
+        do {
+            try validator.process()
+            XCTFail()
+        } catch ProcessingError.fail(let message) {
+            XCTAssertTrue(message.contains("(a: A)"))
+        } catch {
+            XCTFail()
+        }
+    }
+}


### PR DESCRIPTION
Because SourceKit does not provide implementation details of a property provided via `pluginExtension.foo`, we cannot implement an exact detection mechanism. The validator assumes if a property is required by the plugin extension, and the non-core component's dependnecy, yet provided by the core component, then this is a cycle. This is generally true.

Fixes #215