### PR TITLE
Add printer for dependency graph

### DIFF
--- a/Generator/Sources/NeedleFramework/Entry/Generator.swift
+++ b/Generator/Sources/NeedleFramework/Entry/Generator.swift
@@ -72,6 +72,106 @@ public class Generator {
     /// concurrently. `nil` if no limit is set.
     /// - throws: `GeneratorError`.
     public final func generate(from sourceRootPaths: [String], withSourcesListFormat sourcesListFormatValue: String? = nil, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, shouldCollectParsingInfo: Bool, parsingTimeout: Double, exportingTimeout: Double, retryParsingOnTimeoutLimit: Int, concurrencyLimit: Int?) throws {
+        let processor: ProcessorType = .generateSource(additionalImports: additionalImports, 
+                                                       headerDocPath: headerDocPath, 
+                                                       destinationPath: destinationPath, 
+                                                       exportingTimeout: exportingTimeout)
+        try processSourceCode(from: sourceRootPaths, 
+                              withSourcesListFormat: sourcesListFormatValue, 
+                              excludingFilesEndingWith: exclusionSuffixes, 
+                              excludingFilesWithPaths: exclusionPaths, 
+                              shouldCollectParsingInfo: shouldCollectParsingInfo, 
+                              parsingTimeout: parsingTimeout, 
+                              retryParsingOnTimeoutLimit: retryParsingOnTimeoutLimit, 
+                              concurrencyLimit: concurrencyLimit,
+                              processorType: processor)
+    }
+
+    /// Parse Swift source files by recurively scanning the given directories
+    /// or source files included in the given source list files, excluding
+    /// files with specified suffixes. Then print the static dependency tree starting at RootComponent.
+    ///
+    /// - parameter sourceRootUrls: The directories or text files that contain
+    /// a set of Swift source files to parse.
+    /// - parameter sourcesListFormatValue: The optional `String` value of the
+    /// format used by the sources list file. Use `nil` if the given
+    /// `sourceRootPaths` is not a file containing a list of Swift source paths.
+    /// - parameter exclusionSuffixes: The list of file name suffixes to
+    /// check from. If a filename's suffix matches any in the this list,
+    /// the file will not be parsed.
+    /// - parameter exclusionPaths: The list of path components to check.
+    /// If a file's URL path contains any elements in this list, the file
+    /// will not be parsed.
+    /// - parameter shouldCollectParsingInfo: `true` if dependency graph
+    /// parsing information should be collected as tasks are executed. `false`
+    /// otherwise. By collecting execution information, if waiting on the
+    /// completion of a task sequence in the dependency parsing phase times out,
+    /// the reported error contains the relevant information when the timeout
+    /// occurred. The tracking does incur a minor performance cost. This value
+    /// defaults to `false`.
+    /// - parameter parsingTimeout: The timeout value, in seconds, to use for
+    /// waiting on parsing tasks.
+    /// - parameter retryParsingOnTimeoutLimit: The maximum number of times
+    /// parsing Swift source files should be retried in case of timeouts.
+    /// - parameter concurrencyLimit: The maximum number of tasks to execute
+    /// concurrently. `nil` if no limit is set.
+    /// - throws: `GeneratorError`.
+    public final func printDependencyTree(from sourceRootPaths: [String],
+                                          withSourcesListFormat sourcesListFormatValue: String? = nil, 
+                                          excludingFilesEndingWith exclusionSuffixes: [String], 
+                                          excludingFilesWithPaths exclusionPaths: [String],
+                                          shouldCollectParsingInfo: Bool, 
+                                          parsingTimeout: Double, 
+                                          retryParsingOnTimeoutLimit: Int, 
+                                          concurrencyLimit: Int?,
+                                          rootComponentName: String) throws {
+        let processor: ProcessorType = .printDIStructure(rootComponentName: rootComponentName)
+        try processSourceCode(from: sourceRootPaths, 
+                              withSourcesListFormat: sourcesListFormatValue, 
+                              excludingFilesEndingWith: exclusionSuffixes, 
+                              excludingFilesWithPaths: exclusionPaths, 
+                              shouldCollectParsingInfo: shouldCollectParsingInfo, 
+                              parsingTimeout: parsingTimeout, 
+                              retryParsingOnTimeoutLimit: retryParsingOnTimeoutLimit, 
+                              concurrencyLimit: concurrencyLimit,
+                              processorType: processor)
+    }
+
+    // MARK: - Internal
+
+    func generate(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, using executor: SequenceExecutor, withParsingTimeout parsingTimeout: Double, exportingTimeout: Double) throws {
+        let parser = DependencyGraphParser()
+        let (components, imports) = try parser.parse(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, withTimeout: parsingTimeout)
+        let exporter = DependencyGraphExporter()
+        try exporter.export(components, with: imports + additionalImports, to: destinationPath, using: executor, withTimeout: exportingTimeout, include: headerDocPath)
+    }
+
+    // MARK: - Private
+    
+    private enum ProcessorType {
+        case generateSource(additionalImports: [String], headerDocPath: String?, destinationPath: String, exportingTimeout: Double)
+        case printDIStructure(rootComponentName: String)
+    }
+
+    private let sourceKitUtilities: SourceKitUtilities
+
+    private func createExecutor(withName name: String, shouldTrackTaskId: Bool, concurrencyLimit: Int?) -> SequenceExecutor {
+        #if DEBUG
+            return ProcessInfo().environment["SINGLE_THREADED"] != nil ? ImmediateSerialSequenceExecutor() : ConcurrentSequenceExecutor(name: name, qos: .userInteractive, shouldTrackTaskId: shouldTrackTaskId, maxConcurrentTasks: concurrencyLimit)
+        #else
+            return ConcurrentSequenceExecutor(name: name, qos: .userInteractive, shouldTrackTaskId: shouldTrackTaskId, maxConcurrentTasks: concurrencyLimit)
+        #endif
+    }
+
+    private func processSourceCode(from sourceRootPaths: [String], 
+                                   withSourcesListFormat sourcesListFormatValue: String? = nil, 
+                                   excludingFilesEndingWith exclusionSuffixes: [String], 
+                                   excludingFilesWithPaths exclusionPaths: [String], 
+                                   shouldCollectParsingInfo: Bool, 
+                                   parsingTimeout: Double, 
+                                   retryParsingOnTimeoutLimit: Int, 
+                                   concurrencyLimit: Int?,
+                                   processorType: ProcessorType) throws {
         let sourceRootUrls = sourceRootPaths.map { (path: String) -> URL in
             URL(path: path)
         }
@@ -81,7 +181,18 @@ public class Generator {
         var retryParsingCount = 0
         while true {
             do {
-                try generate(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, with: additionalImports, headerDocPath, to: destinationPath, using: executor, withParsingTimeout: parsingTimeout, exportingTimeout: exportingTimeout)
+                switch processorType {
+                    case .generateSource(let additionalImports, let headerDocPath, let destinationPath, let exportingTimeout):
+                        try generate(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, with: additionalImports, headerDocPath, to: destinationPath, using: executor, withParsingTimeout: parsingTimeout, exportingTimeout: exportingTimeout)
+                    case .printDIStructure(let rootComponentName):
+                        try printDIStructure(from : sourceRootUrls,
+                                             withSourcesListFormat: sourcesListFormatValue,
+                                             excludingFilesEndingWith: exclusionSuffixes,
+                                             excludingFilesWithPaths: exclusionPaths,
+                                             withExecutor: executor,
+                                             withParsingTimeout: parsingTimeout,
+                                             withRootComponentName: rootComponentName)
+                }
                 break
             } catch DependencyGraphParserError.timeout(let sourcePath, let taskId) {
                 retryParsingCount += 1
@@ -109,24 +220,16 @@ public class Generator {
         }
     }
 
-    // MARK: - Internal
-
-    func generate(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, using executor: SequenceExecutor, withParsingTimeout parsingTimeout: Double, exportingTimeout: Double) throws {
+    private func printDIStructure(from sourceRootUrls: [URL],
+                                  withSourcesListFormat sourcesListFormatValue: String? = nil, 
+                                  excludingFilesEndingWith exclusionSuffixes: [String], 
+                                  excludingFilesWithPaths exclusionPaths: [String], 
+                                  withExecutor executor: SequenceExecutor,
+                                  withParsingTimeout parsingTimeout: Double,
+                                  withRootComponentName rootComponentName: String) throws {
         let parser = DependencyGraphParser()
-        let (components, imports) = try parser.parse(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, withTimeout: parsingTimeout)
-        let exporter = DependencyGraphExporter()
-        try exporter.export(components, with: imports + additionalImports, to: destinationPath, using: executor, withTimeout: exportingTimeout, include: headerDocPath)
-    }
-
-    // MARK: - Private
-    
-    private let sourceKitUtilities: SourceKitUtilities
-
-    private func createExecutor(withName name: String, shouldTrackTaskId: Bool, concurrencyLimit: Int?) -> SequenceExecutor {
-        #if DEBUG
-            return ProcessInfo().environment["SINGLE_THREADED"] != nil ? ImmediateSerialSequenceExecutor() : ConcurrentSequenceExecutor(name: name, qos: .userInteractive, shouldTrackTaskId: shouldTrackTaskId, maxConcurrentTasks: concurrencyLimit)
-        #else
-            return ConcurrentSequenceExecutor(name: name, qos: .userInteractive, shouldTrackTaskId: shouldTrackTaskId, maxConcurrentTasks: concurrencyLimit)
-        #endif
+        let (components, _) = try parser.parse(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, withTimeout: parsingTimeout)
+        let printer = DependencyGraphPrinter(components: components)
+        printer.printDIStructure(withRootComponentName: rootComponentName)
     }
 }

--- a/Generator/Sources/NeedleFramework/Utilities/DependencyGraphPrinter.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/DependencyGraphPrinter.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+class DependencyGraphPrinter {
+    private let components: [Component]
+    
+    init(components: [Component]) {
+        self.components = components
+    }
+    
+    func printDIStructure(withRootComponentName rootComponentName: String) {
+        var childrenDictionary = [String: [Component]]()
+        
+        let parentChildTuples: [(Component, Component)] = components.flatMap { component in
+            return component.parents.map { ($0, component) }
+        }
+        parentChildTuples.forEach { (parent, child) in
+            var children = childrenDictionary[parent.name] ?? [Component]()
+            children.append(child)
+            childrenDictionary[parent.name] = children
+        }
+        
+        var sortedChildren = [String: [Component]]()
+        childrenDictionary.forEach { (parentName, children) in
+            sortedChildren[parentName] = children.sorted { $0.name < $1.name}
+        }
+        
+        printChildren(ofParent: rootComponentName,
+                      withChildrenDictionary: sortedChildren,
+                      atLevel: 0)
+    }
+    
+    private func printChildren(ofParent componentName: String,
+                               withChildrenDictionary childrenDictionary: [String: [Component]],
+                               atLevel level: Int,
+                               usingLevelSeparator levelSeparator: String = "\t",
+                               usingComponentSuffix componentSuffix: String = "Component") {
+        let separator = String(repeating: levelSeparator, count: level)
+        
+        let name: String = {
+            guard componentName.hasSuffix(componentSuffix) else { return componentName }
+            return String(componentName.dropLast(componentSuffix.count))
+        }()
+        
+        let result = separator + name
+        print(result)
+        
+        let children = childrenDictionary[componentName]
+        children?.forEach { child in
+            printChildren(ofParent: child.name,
+                          withChildrenDictionary: childrenDictionary,
+                          atLevel: level + 1)
+        }
+    }
+}

--- a/Generator/Sources/needle/AbstractCommand.swift
+++ b/Generator/Sources/needle/AbstractCommand.swift
@@ -24,6 +24,9 @@ class AbstractCommand: Command {
     /// The name used to check if this command should be executed.
     let name: String
 
+    /// The default value for waiting timeout in seconds.
+    let defaultTimeout = 30.0
+
     /// Initializer.
     ///
     /// - parameter name: The name used to check if this command should

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -18,9 +18,6 @@ import Foundation
 import NeedleFramework
 import Utility
 
-/// The default value for waiting timeout in seconds.
-fileprivate let defaultTimeout = 30.0
-
 /// The generate command provides the core functionality of needle. It parses
 /// Swift source files by recurively scan the directories starting from the
 /// specified source path, excluding files with specified suffixes. It then

--- a/Generator/Sources/needle/PrintDependencyTreeCommand.swift
+++ b/Generator/Sources/needle/PrintDependencyTreeCommand.swift
@@ -1,0 +1,88 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import NeedleFramework
+import Utility
+
+/// A command that prints out the static dependency tree starting at RootComponent.
+class PrintDependencyTreeCommand: AbstractCommand {
+
+    /// Initializer.
+    ///
+    /// - parameter parser: The argument parser to use.
+    init(parser: ArgumentParser) {
+        super.init(name: "print-dependency-tree", overview: "Prints out the static dependency tree.", parser: parser)
+    }
+
+    /// Setup the arguments using the given parser.
+    ///
+    /// - parameter parser: The argument parser to use.
+    override func setupArguments(with parser: ArgumentParser) {
+        super.setupArguments(with: parser)
+
+        sourceRootPaths = parser.add(positional: "sourceRootPaths", kind: [String].self, strategy: ArrayParsingStrategy.upToNextOption, usage: "Paths to the root folders of Swift source files, or text files containing paths of Swift source files with specified format.", completion: .filename)
+        sourcesListFormat = parser.add(option: "--sources-list-format", kind: String.self, usage: "The format of the Swift sources list file. See SourcesListFileFormat for supported format details", completion: .filename)
+        excludeSuffixes = parser.add(option: "--exclude-suffixes", kind: [String].self, usage: "Filename suffix(es) without extensions to exclude from parsing.", completion: .filename)
+        excludePaths = parser.add(option: "--exclude-paths", kind: [String].self, usage: "Paths components to exclude from parsing.")
+        shouldCollectParsingInfo = parser.add(option: "--collect-parsing-info", shortName: "-cpi", kind: Bool.self, usage: "Whether or not to collect information for parsing execution timeout errors.")
+        parsingTimeout = parser.add(option: "--parsing-timeout", kind: Int.self, usage: "The timeout value, in seconds, to use for waiting on parsing tasks.")
+        retryParsingOnTimeoutLimit = parser.add(option: "--retry-parsing-limit", kind: Int.self, usage: "The maximum number of times parsing Swift source files should be retried in case of timeouts.")
+        concurrencyLimit = parser.add(option: "--concurrency-limit", kind: Int.self, usage: "The maximum number of tasks to execute concurrently.")
+        rootComponentName = parser.add(option: "--root-component-name", kind: String.self, usage: "Root component name for the dependency tree. Defaults to \"RootComponent\".")
+    }
+
+    /// Execute the command.
+    ///
+    /// - parameter arguments: The command line arguments to execute the
+    /// command with.
+    override func execute(with arguments: ArgumentParser.Result) {
+        if let sourceRootPaths = arguments.get(sourceRootPaths) {
+                let sourcesListFormat = arguments.get(self.sourcesListFormat) ?? nil
+                let excludeSuffixes = arguments.get(self.excludeSuffixes) ?? []
+                let excludePaths = arguments.get(self.excludePaths) ?? []
+                let shouldCollectParsingInfo = arguments.get(self.shouldCollectParsingInfo) ?? false
+                let parsingTimeout = arguments.get(self.parsingTimeout, withDefault: defaultTimeout)
+                let retryParsingOnTimeoutLimit = arguments.get(self.retryParsingOnTimeoutLimit) ?? 0
+                let concurrencyLimit = arguments.get(self.concurrencyLimit) ?? nil
+                let rootComponentName = arguments.get(self.rootComponentName) ?? "RootComponent"
+
+                let sourceKitUtilities = SourceKitUtilitiesImpl(processUtilities: ProcessUtilitiesImpl())
+                let generator = Generator(sourceKitUtilities: sourceKitUtilities)
+                do {
+                    try generator.printDependencyTree(from: sourceRootPaths, withSourcesListFormat: sourcesListFormat, excludingFilesEndingWith: excludeSuffixes, excludingFilesWithPaths: excludePaths, shouldCollectParsingInfo: shouldCollectParsingInfo, parsingTimeout: parsingTimeout, retryParsingOnTimeoutLimit: retryParsingOnTimeoutLimit, concurrencyLimit: concurrencyLimit, rootComponentName: rootComponentName)
+                } catch GeneratorError.withMessage(let message) {
+                    fatalError(message)
+                } catch {
+                    fatalError("Unknown error: \(error)")
+                }
+        } else {
+            fatalError("Missing source files root directories.")
+        }
+    }
+
+    // MARK: - Private
+
+    private var sourceRootPaths: PositionalArgument<[String]>!
+    private var sourcesListFormat: OptionArgument<String>!
+    private var excludeSuffixes: OptionArgument<[String]>!
+    private var excludePaths: OptionArgument<[String]>!
+    private var shouldCollectParsingInfo: OptionArgument<Bool>!
+    private var parsingTimeout: OptionArgument<Int>!
+    private var retryParsingOnTimeoutLimit: OptionArgument<Int>!
+    private var concurrencyLimit: OptionArgument<Int>!
+    private var rootComponentName: OptionArgument<String>!
+}

--- a/Generator/Sources/needle/main.swift
+++ b/Generator/Sources/needle/main.swift
@@ -34,7 +34,8 @@ func main() {
 private func initializeCommands(with parser: ArgumentParser) -> [Command] {
     return [
         VersionCommand(parser: parser),
-        GenerateCommand(parser: parser)
+        GenerateCommand(parser: parser),
+        PrintDependencyTreeCommand(parser: parser)
     ]
 }
 


### PR DESCRIPTION
This command line parameter prints out the static dependency tree starting at RootComponent.

Command:
`needle generate NeedleGenerated.swift apps/freight/ -print-dep`

Example Output:
```
Root
	LoggedIn
		Active
	LoggedOut
		EntryCore
```