### PR TITLE
Support multi-line generic coding style

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
@@ -71,6 +71,7 @@ class PluginizedASTParserTask: AbstractTask<PluginizedDependencyGraphNode> {
 // MARK: - SourceKit AST Parsing Utilities
 
 private extension Structure {
+
     var isPluginizedComponent: Bool {
         let regex = Regex("^(\(needleModuleName).)?PluginizedComponent *<(.+)>")
         return inheritedTypes.contains { (type: String) -> Bool in

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTParserTask.swift
@@ -16,6 +16,7 @@
 
 import Concurrency
 import Foundation
+import SourceKittenFramework
 
 /// A task that parses Swift AST into dependency graph data models.
 class ASTParserTask: AbstractTask<DependencyGraphNode> {
@@ -54,5 +55,23 @@ class ASTParserTask: AbstractTask<DependencyGraphNode> {
             }
         }
         return (components, dependencies)
+    }
+}
+
+// MARK: - SourceKit AST Parsing Utilities
+
+private extension Structure {
+
+    /// Check if this structure represents a `Component` subclass.
+    var isComponent: Bool {
+        let regex = Regex("^(\(needleModuleName).)?Component *<(.+)>")
+        return inheritedTypes.contains { (type: String) -> Bool in
+            regex.firstMatch(in: type) != nil
+        }
+    }
+
+    /// Check if this structure represents a `Dependency` protocol.
+    var isDependencyProtocol: Bool {
+        return inheritedTypes.contains("Dependency") || inheritedTypes.contains("\(needleModuleName).Dependency")
     }
 }

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTUtils.swift
@@ -17,8 +17,8 @@
 import Foundation
 import SourceKittenFramework
 
-/// Extension of SourceKitten `Structure` to provide easy access to AST
-/// properties.
+/// Extension of SourceKitten `Structure` to provide easy access to a set
+/// of common AST properties.
 extension Structure {
 
     /// The substructures of this structure.
@@ -33,19 +33,6 @@ extension Structure {
             }
         }
         return result
-    }
-
-    /// Check if this structure represents a `Component` subclass.
-    var isComponent: Bool {
-        let regex = Regex("^(\(needleModuleName).)?Component *<(.+)>")
-        return inheritedTypes.contains { (type: String) -> Bool in
-            regex.firstMatch(in: type) != nil
-        }
-    }
-
-    /// Check if this structure represents a `Dependency` protocol.
-    var isDependencyProtocol: Bool {
-        return inheritedTypes.contains("Dependency") || inheritedTypes.contains("\(needleModuleName).Dependency")
     }
 
     /// The type name of this structure.
@@ -133,7 +120,7 @@ extension Structure {
     var inheritedTypes: [String] {
         let types = dictionary["key.inheritedtypes"] as? [SourceKitRepresentable] ?? []
         return types.compactMap { (item: SourceKitRepresentable) -> String? in
-            (item as? [String: String])?["key.name"]
+            ((item as? [String: String])?["key.name"])?.replacingOccurrences(of: "\n", with: "").replacingOccurrences(of: " ", with: "")
         }
     }
 

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -12,7 +12,9 @@ protocol RandomProtocol {
 
 let randomValue = 1234
 
-class MyComponent: NeedleFoundation.Component<MyDependency> {
+class MyComponent: NeedleFoundation.Component<
+MyDependency
+> {
 
     let stream: Stream = Stream()
 
@@ -79,7 +81,10 @@ protocol BExtension: PluginExtension {
     var myPluginPoint: MyPluginPoint { get }
 }
 
-class SomePluginizedComp: PluginizedComponent<ADependency, BExtension, SomeNonCoreComponent>, Stuff {
+class SomePluginizedComp: PluginizedComponent<
+ADependency,
+BExtension, SomeNonCoreComponent
+>, Stuff {
     var tv: Tv {
         return LGOLEDTv()
     }

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/MultiLineInheritedTypes.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/MultiLineInheritedTypes.swift
@@ -1,0 +1,7 @@
+class MyClass: SuperClass<
+    Blah,
+    Foo,
+    Bar
+> {
+
+}

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/SingleLineInheritedTypes.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/SingleLineInheritedTypes.swift
@@ -1,0 +1,3 @@
+class MyClass2: SuperClass<Blah, Foo, Bar> {
+
+}

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ASTUtilsTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ASTUtilsTests.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SourceKittenFramework
+import XCTest
+@testable import NeedleFramework
+
+class ASTUtilsTests: AbstractParserTests {
+
+    func test_inheritedTypes_withSingleLine_verifyResult() {
+        let structure = ast(for: "SingleLineInheritedTypes.swift").substructures[0]
+        let types = structure.inheritedTypes
+
+        XCTAssertEqual(types, ["SuperClass<Blah,Foo,Bar>"])
+    }
+
+    func test_inheritedTypes_withMultiLine_verifyResult() {
+        let structure = ast(for: "MultiLineInheritedTypes.swift").substructures[0]
+        let types = structure.inheritedTypes
+
+        XCTAssertEqual(types, ["SuperClass<Blah,Foo,Bar>"])
+    }
+
+    private func ast(for fileName: String) -> Structure {
+        let fileUrl = fixtureUrl(for: fileName)
+        let content = try! String(contentsOf: fileUrl)
+        let file = File(contents: content)
+        return try! Structure(file: file)
+    }
+}


### PR DESCRIPTION
Add support for multi-line generic coding style where generics of a class can be placed on new lines. Such as:
```
class MyClass: SuperClass<
    Blah,
    Foo,
    Bar
> {

}
```

Also moved `ASTParserTask` only extensions into a `private` extension in the same file.

Fixes #224 