### PR TITLE
Remove redundant string trimming

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTParserTask.swift
@@ -116,9 +116,9 @@ private extension Structure {
             if generics.count < 3 {
                 fatalError("\(name) as a PluginizedComponent should have 3 generic types. Instead of \(genericsString)")
             }
-            let dependencyProtocolName = generics[0].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-            let pluginExtensionName = generics[1].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-            let nonCoreComponentName = generics[2].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            let dependencyProtocolName = String(generics[0])
+            let pluginExtensionName = String(generics[1])
+            let nonCoreComponentName = String(generics[2])
             return (dependencyProtocolName, pluginExtensionName, nonCoreComponentName)
         } else {
             fatalError("\(name) is being parsed as a PluginizedComponent. Yet its generic types cannot be parsed. \(inheritedTypes)")

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -13,7 +13,7 @@ protocol RandomProtocol {
 let randomValue = 1234
 
 class MyComponent: NeedleFoundation.Component<
-MyDependency
+    MyDependency
 > {
 
     let stream: Stream = Stream()
@@ -42,7 +42,7 @@ protocol SomeNonCoreDependency: Dependency {
     var maybeNonCoreDep: MaybeDep? { get }
 }
 
-class SomeNonCoreComponent: NeedleFoundation.NonCoreComponent<SomeNonCoreDependency> {
+class SomeNonCoreComponent: NeedleFoundation.NonCoreComponent<    SomeNonCoreDependency  > {
     var newNonCoreObject: NonCoreObject? {
         return NonCoreObject()
     }
@@ -82,8 +82,8 @@ protocol BExtension: PluginExtension {
 }
 
 class SomePluginizedComp: PluginizedComponent<
-ADependency,
-BExtension, SomeNonCoreComponent
+  ADependency,
+BExtension,    SomeNonCoreComponent
 >, Stuff {
     var tv: Tv {
         return LGOLEDTv()


### PR DESCRIPTION
Since the previous PR #230 had added trimming into the `inheritedTypes` property, the `PluginizedASTParserTask` no longer needs to perform additional trimming on the generic types.