### PR TITLE
Convert all fatalError in NeedleFramework to GeneratorError

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.20.0"),
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
-        .package(url: "https://github.com/uber/swift-concurrency.git", from: "0.6.5"),
+        .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
     ],
     targets: [
         .target(

--- a/Generator/Sources/NeedleFramework/Entry/Generator.swift
+++ b/Generator/Sources/NeedleFramework/Entry/Generator.swift
@@ -210,12 +210,8 @@ public class Generator {
                     }
                     sourceKitUtilities.initialize()
                 }
-            } catch DependencyGraphExporterError.timeout(let componentName) {
-                throw GeneratorError.withMessage("Generating dependency provider for \(componentName) timed out.")
-            } catch DependencyGraphExporterError.unableToWriteFile(let outputFile) {
-                throw GeneratorError.withMessage("Failed to export contents to \(outputFile)")
             } catch {
-                throw GeneratorError.withMessage("Unknown error \(error).")
+                throw error
             }
         }
     }

--- a/Generator/Sources/NeedleFramework/Generating/FileContentLoaderTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/FileContentLoaderTask.swift
@@ -32,14 +32,10 @@ class FileContentLoaderTask: AbstractTask<String> {
     /// Execute the task and returns the file content.
     ///
     /// - returns: The file content as `String`.
-    override func execute() -> String {
+    /// - throws: Any error occurred during execution.
+    override func execute() throws -> String {
         let url = URL(fileURLWithPath: filePath)
-        do {
-            return try String(contentsOf: url)
-        } catch (let error) {
-            warning("File content cannot be loaded from \(filePath) \(error)")
-            return ""
-        }
+        return try String(contentsOf: url)
     }
 
     // MARK: - Private

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/NonCoreComponentLinker.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/NonCoreComponentLinker.swift
@@ -42,7 +42,7 @@ class NonCoreComponentLinker: Processor {
 
         for pluginizedComponent in pluginizedComponents {
             guard let nonCoreComponent = nonCoreMap[pluginizedComponent.nonCoreComponentType] else {
-                throw ProcessingError.fail("Cannot find \(pluginizedComponent.data.name)'s non-core component with type name \(pluginizedComponent.nonCoreComponentType)")
+                throw GeneratorError.withMessage("Cannot find \(pluginizedComponent.data.name)'s non-core component with type name \(pluginizedComponent.nonCoreComponentType)")
             }
 
             pluginizedComponent.nonCoreComponent = nonCoreComponent

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/PluginExtensionCycleValidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/PluginExtensionCycleValidator.swift
@@ -38,10 +38,10 @@ class PluginExtensionCycleValidator: Processor {
     func process() throws {
         for component in pluginizedComponents {
             guard let pluginExtension = component.pluginExtension else {
-                throw ProcessingError.fail("\(component.data.name)'s plugin extension has not been linked.")
+                throw GeneratorError.withMessage("\(component.data.name)'s plugin extension has not been linked.")
             }
             guard let nonCoreDependency = component.nonCoreComponent?.dependencyProtocol else {
-                throw ProcessingError.fail("\(component.data.name)'s non-core component dependency has not been linked.")
+                throw GeneratorError.withMessage("\(component.data.name)'s non-core component dependency has not been linked.")
             }
 
             let nonCoreDepProperties = Set<Property>(nonCoreDependency.properties)
@@ -62,7 +62,7 @@ class PluginExtensionCycleValidator: Processor {
                         return "(\(property.name): \(property.type))"
                     }
                     .joined(separator: ", ")
-                throw ProcessingError.fail("\(component.data.name) contains cyclic plugin extension properties \(cyclicPropertiesString).")
+                throw GeneratorError.withMessage("\(component.data.name) contains cyclic plugin extension properties \(cyclicPropertiesString).")
             }
         }
     }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/PluginExtensionLinker.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Processors/PluginExtensionLinker.swift
@@ -43,7 +43,7 @@ class PluginExtensionLinker: Processor {
         for pluginizedComponent in pluginizedComponents {
             pluginizedComponent.pluginExtension = extensionMap[pluginizedComponent.pluginExtensionType]
             if pluginizedComponent.pluginExtension == nil {
-                throw ProcessingError.fail("Cannot find \(pluginizedComponent.data.name)'s plugin extension with type name \(pluginizedComponent.pluginExtensionType)")
+                throw GeneratorError.withMessage("Cannot find \(pluginizedComponent.data.name)'s plugin extension with type name \(pluginizedComponent.pluginExtensionType)")
             }
         }
     }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedFileFilterTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedFileFilterTask.swift
@@ -43,7 +43,8 @@ class PluginizedFileFilterTask: AbstractTask<FilterResult> {
     /// should be parsed.
     ///
     /// - returns: The `FilterResult`.
-    override func execute() -> FilterResult {
+    /// - throws: Any error occurred during execution.
+    override func execute() throws -> FilterResult {
         let urlFilter = UrlFilter(url: url, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths)
         if !urlFilter.filter() {
             return FilterResult.skip
@@ -58,7 +59,7 @@ class PluginizedFileFilterTask: AbstractTask<FilterResult> {
                 return FilterResult.skip
             }
         } else {
-            fatalError("Failed to read file at \(url)")
+            throw GeneratorError.withMessage("Failed to read file at \(url)")
         }
     }
 

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/AncestorCycleValidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/AncestorCycleValidator.swift
@@ -36,7 +36,7 @@ class AncestorCycleValidator: Processor {
                 let pathNames = cyclePath.map { (element: ASTComponent) -> String in
                     element.name
                 } + [component.name]
-                throw ProcessingError.fail("Dependency cycle detected along the path of \(pathNames.joined(separator: "->"))")
+                throw GeneratorError.withMessage("Dependency cycle detected along the path of \(pathNames.joined(separator: "->"))")
             }
         }
     }

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/DependencyLinker.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/DependencyLinker.swift
@@ -39,7 +39,7 @@ class DependencyLinker: Processor {
             if let dependency = nameToDependency[component.dependencyProtocolName] {
                 component.dependencyProtocol = dependency
             } else if !Dependency.isEmptyDependency(name: component.dependencyProtocolName) {
-                throw ProcessingError.fail("Missing dependency protocol data model with name \(component.dependencyProtocolName), for \(component.name).")
+                throw GeneratorError.withMessage("Missing dependency protocol data model with name \(component.dependencyProtocolName), for \(component.name).")
             }
         }
     }

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/DuplicateValidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/DuplicateValidator.swift
@@ -49,7 +49,7 @@ class DuplicateValidator: Processor {
             if map[component.name] == nil {
                 map[component.name] = component.name
             } else {
-                throw ProcessingError.fail("Needle does not support components with the same name \(component.name)")
+                throw GeneratorError.withMessage("Needle does not support components with the same name \(component.name)")
             }
         }
     }
@@ -60,7 +60,7 @@ class DuplicateValidator: Processor {
             if map[dependency.name] == nil {
                 map[dependency.name] = dependency.name
             } else {
-                throw ProcessingError.fail("Needle does not support dependency protocols with the same name \(dependency.name)")
+                throw GeneratorError.withMessage("Needle does not support dependency protocols with the same name \(dependency.name)")
             }
         }
     }

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/Processor.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/Processor.swift
@@ -16,17 +16,11 @@
 
 import Foundation
 
-/// The processing error types.
-enum ProcessingError: Error {
-    /// Processing failed with given error.
-    case fail(String)
-}
-
 /// A post parsing utility unit that processes the parssed data model.
 protocol Processor {
 
     /// Process the data models.
     ///
-    /// - throws: `ProcessingError` if any errors occurred during processing.
+    /// - throws: `GeneratorError` if any errors occurred during processing.
     func process() throws
 }

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTProducerTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTProducerTask.swift
@@ -35,14 +35,15 @@ class ASTProducerTask: AbstractTask<AST> {
     /// Execute the task and return the AST structure data model.
     ///
     /// - returns: The `AST` data model.
-    override func execute() -> AST {
+    /// - throws: Any error occurred during execution.
+    override func execute() throws -> AST {
         let file = File(contents: sourceContent)
         do {
             let structure = try Structure(file: file)
             let imports = parseImports()
             return AST(structure: structure, imports: imports)
         } catch {
-            fatalError("Failed to parse AST for source at \(sourceUrl)")
+            throw GeneratorError.withMessage("Failed to parse AST for source at \(sourceUrl)")
         }
     }
 

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/FileFilterTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/FileFilterTask.swift
@@ -49,7 +49,8 @@ class FileFilterTask: AbstractTask<FilterResult> {
     /// should be parsed.
     ///
     /// - returns: The `FilterResult`.
-    override func execute() -> FilterResult {
+    /// - throws: Any error occurred during execution.
+    override func execute() throws -> FilterResult {
         let urlFilter = UrlFilter(url: url, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths)
         if !urlFilter.filter() {
             return FilterResult.skip
@@ -64,7 +65,7 @@ class FileFilterTask: AbstractTask<FilterResult> {
                 return FilterResult.skip
             }
         } else {
-            fatalError("Failed to read file at \(url)")
+            throw GeneratorError.withMessage("Failed to read file at \(url)")
         }
     }
 

--- a/Generator/Sources/NeedleFramework/Utilities/FileEnumerator.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/FileEnumerator.swift
@@ -40,17 +40,6 @@ enum SourcesListFileFormat {
     }
 }
 
-/// The set of errors may be thrown by the `FileEnumerator`.
-enum FileEnumerationError: Error {
-    /// Failed to read the text file that is supposed to contain a list
-    /// of paths on each line.
-    case failedToReadSourcesList(URL, Error)
-    /// Failed to traverse a directory specified by given URL.
-    case failedToTraverseDirectory(URL)
-    /// Failed to parse sources list format value.
-    case failedToParseSourcesListFormatValue(String)
-}
-
 /// A utility class that provides file enumeration from a root directory.
 class FileEnumerator {
 
@@ -96,7 +85,7 @@ class FileEnumerator {
             if let parsedFormat = SourcesListFileFormat.format(with: stringValue) {
                 return parsedFormat
             } else {
-                throw FileEnumerationError.failedToParseSourcesListFormatValue(stringValue)
+                throw GeneratorError.withMessage("Failed to parse sources list format \(stringValue)")
             }
         } else {
             return defaultFormat
@@ -120,7 +109,7 @@ class FileEnumerator {
                     URL(fileURLWithPath: path)
                 }
         } catch {
-            throw FileEnumerationError.failedToReadSourcesList(listUrl, error)
+            throw GeneratorError.withMessage("Failed to read source paths from list file at \(listUrl) \(error)")
         }
     }
 
@@ -171,7 +160,7 @@ class FileEnumerator {
         if let enumerator = FileManager.default.enumerator(at: rootUrl, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles], errorHandler: errorHandler) {
             return enumerator
         } else {
-            throw FileEnumerationError.failedToTraverseDirectory(rootUrl)
+            throw GeneratorError.withMessage("Failed traverse \(rootUrl)")
         }
     }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderContentTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderContentTaskTests.swift
@@ -26,7 +26,7 @@ class DependencyProviderContentTaskTests: AbstractGeneratorTests {
         for component in components {
             let providers = DependencyProviderDeclarerTask(component: component).execute()
             let task = DependencyProviderContentTask(providers: providers)
-            let processedProviders = task.execute()
+            let processedProviders = try! task.execute()
             switch component.name {
             case "GameComponent":
                 verifyGameComponent(processedProviders)

--- a/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderSerializerTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderSerializerTaskTests.swift
@@ -25,7 +25,7 @@ class DependencyProviderSerializerTaskTests: AbstractGeneratorTests {
         let (components, imports) = sampleProjectParsed()
         for component in components {
             let providers = DependencyProviderDeclarerTask(component: component).execute()
-            let processedProviders = DependencyProviderContentTask(providers: providers).execute()
+            let processedProviders = try! DependencyProviderContentTask(providers: providers).execute()
             for provider in processedProviders {
                 let serializedProviders = DependencyProviderSerializerTask(providers: [provider]).execute()
                 XCTAssertEqual(serializedProviders.count, 1)

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyProviderContentTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyProviderContentTaskTests.swift
@@ -28,7 +28,7 @@ class PluginizedDependencyProviderContentTaskTests: AbstractPluginizedGeneratorT
             let declareTask = DependencyProviderDeclarerTask(component: component)
             let providers = declareTask.execute()
             let contentTask = PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents)
-            let processedProviders = contentTask.execute()
+            let processedProviders = try! contentTask.execute()
 
             switch component.name {
             case "LoggedOutComponent":
@@ -50,7 +50,7 @@ class PluginizedDependencyProviderContentTaskTests: AbstractPluginizedGeneratorT
             let declareTask = DependencyProviderDeclarerTask(component: component.data)
             let providers = declareTask.execute()
             let contentTask = PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents)
-            let processedProviders = contentTask.execute()
+            let processedProviders = try! contentTask.execute()
 
             switch component.data.name {
             case "GameComponent":

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Serializers/Pluginized/PluginizedPropertiesSerializerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Serializers/Pluginized/PluginizedPropertiesSerializerTests.swift
@@ -25,7 +25,7 @@ class PluginizedPropertiesSerializerTests: AbstractPluginizedGeneratorTests {
         let (components, pluginizedComponents, _) = pluginizedSampleProjectParsed()
         for component in components {
             let providers = DependencyProviderDeclarerTask(component: component).execute()
-            let processedProviders = PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents).execute()
+            let processedProviders = try! PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents).execute()
             for provider in processedProviders {
                 if provider.processedProperties.isEmpty {
                     continue
@@ -47,7 +47,7 @@ class PluginizedPropertiesSerializerTests: AbstractPluginizedGeneratorTests {
 
         for pluginizedComponent in pluginizedComponents {
             let providers = DependencyProviderDeclarerTask(component: pluginizedComponent.data).execute()
-            let processedProviders = PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents).execute()
+            let processedProviders = try! PluginizedDependencyProviderContentTask(providers: providers, pluginizedComponents: pluginizedComponents).execute()
             for provider in processedProviders {
                 let serializedProperties = PluginizedPropertiesSerializer(provider: provider).serialize()
 

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ASTParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ASTParserTaskTests.swift
@@ -27,7 +27,7 @@ class ASTParserTaskTests: AbstractParserTests {
         let imports = ["import UIKit", "import RIBs", "import Foundation"]
 
         let task = ASTParserTask(ast: AST(structure: structure, imports: imports))
-        _ = task.execute()
+        _ = try! task.execute()
 
         let expected = ["PrivateDependency (candy: Candy) property is fileprivate, therefore inaccessible on DI graph.",
                         "PrivateDependency (cheese: Cheese) property is fileprivate, therefore inaccessible on DI graph.",
@@ -43,7 +43,7 @@ class ASTParserTaskTests: AbstractParserTests {
         let imports = ["import UIKit", "import RIBs", "import Foundation"]
 
         let task = ASTParserTask(ast: AST(structure: structure, imports: imports))
-        let node = task.execute()
+        let node = try! task.execute()
 
         XCTAssertEqual(node.components.count, 2)
 

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ASTProducerTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ASTProducerTaskTests.swift
@@ -26,7 +26,7 @@ class ASTProducerTaskTests: AbstractParserTests {
         let astContent = try! Structure(file: File(contents: sourceContent))
 
         let task = ASTProducerTask(sourceUrl: sourceUrl, sourceContent: sourceContent)
-        let result = task.execute()
+        let result = try! task.execute()
 
         XCTAssertEqual(result.structure, astContent)
         XCTAssertEqual(result.imports, ["import UIKit", "import RIBs", "import Foundation"])

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
@@ -89,13 +89,13 @@ class MockSequenceExecutor: SequenceExecutor {
     func executeSequence<SequenceResultType>(from initialTask: Task, with execution: @escaping (Task, Any) -> SequenceExecution<SequenceResultType>) -> SequenceExecutionHandle<SequenceResultType> {
         executeCallCount += 1
 
-        var result = initialTask.typeErasedExecute()
+        var result = try! initialTask.typeErasedExecute()
         var executionResult = execution(initialTask, result)
         executionHandler?(initialTask, result)
         while true {
             switch executionResult {
             case .continueSequence(let task):
-                result = task.typeErasedExecute()
+                result = try! task.typeErasedExecute()
                 executionResult = execution(task, result)
                 executionHandler?(task, result)
             case .endOfSequence(let finalResult):

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyLinkerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyLinkerTests.swift
@@ -39,7 +39,8 @@ class DependencyLinkerTests: AbstractParserTests {
         do {
             try linker.process()
             XCTFail()
-        } catch ProcessingError.fail(_) {
+        } catch GeneratorError.withMessage(_) {
+            // Success.
         } catch {
             XCTFail()
         }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DuplicateValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DuplicateValidatorTests.swift
@@ -38,7 +38,7 @@ class DuplicateValidatorTests: XCTestCase {
 
         do  {
             try validator.process()
-        } catch ProcessingError.fail(let message) {
+        } catch GeneratorError.withMessage(let message) {
             XCTAssertTrue(message.contains("ha1"))
         } catch {
             XCTFail()
@@ -64,7 +64,7 @@ class DuplicateValidatorTests: XCTestCase {
 
         do  {
             try validator.process()
-        } catch ProcessingError.fail(let message) {
+        } catch GeneratorError.withMessage(let message) {
             XCTAssertTrue(message.contains("d1"))
         } catch {
             XCTFail()

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/FileEnumeratorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/FileEnumeratorTests.swift
@@ -92,8 +92,8 @@ class FileEnumeratorTests: AbstractParserTests {
             XCTFail()
         } catch {
             switch error {
-            case FileEnumerationError.failedToReadSourcesList(let url, _):
-                XCTAssertEqual(url, sourcesListUrl)
+            case GeneratorError.withMessage(let message):
+                XCTAssertTrue(message.contains(sourcesListUrl.absoluteString))
             default:
                 XCTFail()
             }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/FileFilterTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/FileFilterTaskTests.swift
@@ -23,7 +23,7 @@ class FileFilterTaskTests: AbstractParserTests {
         let fileUrl = fixtureUrl(for: "NonSwift.json")
         let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
         switch result {
         case .shouldParse(_, _):
             XCTFail()
@@ -37,7 +37,7 @@ class FileFilterTaskTests: AbstractParserTests {
         let content = try! String(contentsOf: fileUrl)
         let excludeSuffixTask = FileFilterTask(url: fileUrl, exclusionSuffixes: ["Sample"], exclusionPaths: [])
 
-        var result = excludeSuffixTask.execute()
+        var result = try! excludeSuffixTask.execute()
 
         switch result {
         case .shouldParse(_, _):
@@ -48,7 +48,7 @@ class FileFilterTaskTests: AbstractParserTests {
 
         let includeSuffixTask = FileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        result = includeSuffixTask.execute()
+        result = try! includeSuffixTask.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -63,7 +63,7 @@ class FileFilterTaskTests: AbstractParserTests {
         let fixturesURL = fixtureUrl(for: "NonNeedleComponent.swift")
         let task = FileFilterTask(url: fixturesURL, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(_, _):
@@ -77,7 +77,7 @@ class FileFilterTaskTests: AbstractParserTests {
         let fixturesURL = fixtureUrl(for: "NonInheritanceComponent.swift")
         let task = FileFilterTask(url: fixturesURL, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(_, _):
@@ -92,7 +92,7 @@ class FileFilterTaskTests: AbstractParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -108,7 +108,7 @@ class FileFilterTaskTests: AbstractParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -124,7 +124,7 @@ class FileFilterTaskTests: AbstractParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/NonCoreComponentLinkerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/NonCoreComponentLinkerTests.swift
@@ -41,7 +41,8 @@ class NonCoreComponentLinkerTests: AbstractParserTests {
         do {
             try linker.process()
             XCTFail()
-        } catch ProcessingError.fail(_) {
+        } catch GeneratorError.withMessage(_) {
+            // Success.
         } catch {
             XCTFail()
         }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionCycleValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionCycleValidatorTests.swift
@@ -57,7 +57,7 @@ class PluginExtensionCycleValidatorTests: AbstractPluginizedParserTests {
         do {
             try validator.process()
             XCTFail()
-        } catch ProcessingError.fail(let message) {
+        } catch GeneratorError.withMessage(let message) {
             XCTAssertTrue(message.contains("(a: A)"))
         } catch {
             XCTFail()

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionLinkerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionLinkerTests.swift
@@ -40,7 +40,8 @@ class PluginExtensionLinkerTests: AbstractParserTests {
         do {
             try linker.process()
             XCTFail()
-        } catch ProcessingError.fail(_) {
+        } catch GeneratorError.withMessage(_) {
+            // Success.
         } catch {
             XCTFail()
         }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedASTParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedASTParserTaskTests.swift
@@ -27,7 +27,7 @@ class PluginizedASTParserTaskTests: AbstractParserTests {
         let imports = ["import UIKit", "import RIBs", "import Foundation"]
 
         let task = PluginizedASTParserTask(ast: AST(structure: structure, imports: imports))
-        let node = task.execute()
+        let node = try! task.execute()
 
 
         // Regular components.

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedFileFilterTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedFileFilterTaskTests.swift
@@ -23,7 +23,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let fileUrl = fixtureUrl(for: "NonSwift.json")
         let task = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
         switch result {
         case .shouldParse(_, _):
             XCTFail()
@@ -37,7 +37,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let content = try! String(contentsOf: fileUrl)
         let excludeSuffixTask = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: ["Sample"], exclusionPaths: [])
 
-        var result = excludeSuffixTask.execute()
+        var result = try! excludeSuffixTask.execute()
 
         switch result {
         case .shouldParse(_, _):
@@ -48,7 +48,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
 
         let includeSuffixTask = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        result = includeSuffixTask.execute()
+        result = try! includeSuffixTask.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -63,7 +63,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let fixturesURL = fixtureUrl(for: "NonNeedleComponent.swift")
         let task = PluginizedFileFilterTask(url: fixturesURL, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(_, _):
@@ -77,7 +77,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let fixturesURL = fixtureUrl(for: "NonInheritanceComponent.swift")
         let task = PluginizedFileFilterTask(url: fixturesURL, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(_, _):
@@ -92,7 +92,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -108,7 +108,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -124,7 +124,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -140,7 +140,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = FileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -156,7 +156,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):
@@ -172,7 +172,7 @@ class PluginizedFileFilterTaskTests: AbstractPluginizedParserTests {
         let content = try! String(contentsOf: fileUrl)
         let task = PluginizedFileFilterTask(url: fileUrl, exclusionSuffixes: [], exclusionPaths: [])
 
-        let result = task.execute()
+        let result = try! task.execute()
 
         switch result {
         case .shouldParse(let sourceUrl, let sourceContent):


### PR DESCRIPTION
This enables unit testing of error cases.

Also removed unnecessary specific error types, since they are not being handled beyond just reporting `fatalError`. These are replaced with the generic `GeneratorError.withMessage`.