### PR TITLE
Multithread ComponentInstantiationValidator

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Processors/ComponentInstantiationValidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/ComponentInstantiationValidator.swift
@@ -14,6 +14,7 @@
 //  limitations under the License.
 //
 
+import Concurrency
 import Foundation
 
 /// A post processing utility class that checks if any components are
@@ -24,11 +25,17 @@ class ComponentInstantiationValidator: Processor {
     ///
     /// - parameter components: The list of components that are parsed out.
     /// - parameter fileContents: The list of all parsed source files.
-    init(components: [ASTComponent], fileContents: [String]) {
+    /// - parameter executor: The execution to use for executing validation
+    /// tasks.
+    /// - parameter timeout: The timeout value to use to wait for each
+    /// individual validations.
+    init(components: [ASTComponent], fileContents: [String], executor: SequenceExecutor, timeout: Double) {
         self.componentNames = Set(components.map({ (component: ASTComponent) -> String in
             component.name
         }))
         self.fileContents = fileContents
+        self.executor = executor
+        self.timeout = timeout
     }
 
     /// Process the data models.
@@ -36,26 +43,24 @@ class ComponentInstantiationValidator: Processor {
     /// - throws: `ProcessingError` if any component instantiation is
     /// invalid.
     func process() throws {
+        // Enqueue validation tasks.
+        var handles = [SequenceExecutionHandle<ComponentInstantiationValidationResult>]()
         for content in fileContents {
-            let matches = componentInstantiationRegex.matches(in: content)
-            for match in matches {
-                let componentName = content.substring(with: match.range(at: 1))
-                if let componentName = componentName, componentNames.contains(componentName) {
-                    let matchRange = match.range(at: 0)
-                    // Use match range + 5 as the range to extract the argument.
-                    // This includes one extra character after the expected `self`
-                    // argument to check for cases such as `self.blah`.
-                    let argRange = NSRange(location: matchRange.location + matchRange.length, length: 5)
-                    let arg = content.substring(with: argRange)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-                    // Special case for root component, where it is instantiated
-                    // with BootstrapComponent().
-                    let rootArgRange = NSRange(location: matchRange.location + matchRange.length, length: 20)
-                    let rootArg = content.substring(with: rootArgRange)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            let task = ComponentInstantiationValidationTask(fileContent: content, componentNames: componentNames)
+            let handle = executor.executeSequence(from: task) { (_, result: Any) -> SequenceExecution<ComponentInstantiationValidationResult> in
+                SequenceExecution.endOfSequence(result as! ComponentInstantiationValidationResult)
+            }
+            handles.append(handle)
+        }
 
-                    if let arg = arg, !validate(componentInstantiationArg: arg, and: rootArg) {
-                        throw GeneratorError.withMessage("\(componentName) is instantiated incorrectly. All components must be instantiated by parent components, by passing `self` as the argument to the parent parameter.")
-                    }
-                }
+        // Process validation results.
+        for handle in handles {
+            let result = try handle.await(withTimeout: timeout)
+            switch result {
+            case .success:
+                break
+            case .failure(let componentName):
+                throw GeneratorError.withMessage("\(componentName) is instantiated incorrectly. All components must be instantiated by parent components, by passing `self` as the argument to the parent parameter.")
             }
         }
     }
@@ -64,6 +69,51 @@ class ComponentInstantiationValidator: Processor {
 
     private let componentNames: Set<String>
     private let fileContents: [String]
+    private let executor: SequenceExecutor
+    private let timeout: Double
+}
+
+private enum ComponentInstantiationValidationResult {
+    case success
+    case failure(String)
+}
+
+private class ComponentInstantiationValidationTask: AbstractTask<ComponentInstantiationValidationResult> {
+
+    fileprivate init(fileContent: String, componentNames: Set<String>) {
+        self.fileContent = fileContent
+        self.componentNames = componentNames
+    }
+
+    fileprivate override func execute() throws -> ComponentInstantiationValidationResult {
+        let matches = componentInstantiationRegex.matches(in: fileContent)
+        for match in matches {
+            let componentName = fileContent.substring(with: match.range(at: 1))
+            if let componentName = componentName, componentNames.contains(componentName) {
+                let matchRange = match.range(at: 0)
+                // Use match range + 5 as the range to extract the argument.
+                // This includes one extra character after the expected `self`
+                // argument to check for cases such as `self.blah`.
+                let argRange = NSRange(location: matchRange.location + matchRange.length, length: 5)
+                let arg = fileContent.substring(with: argRange)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+                // Special case for root component, where it is instantiated
+                // with BootstrapComponent().
+                let rootArgRange = NSRange(location: matchRange.location + matchRange.length, length: 20)
+                let rootArg = fileContent.substring(with: rootArgRange)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+
+                if let arg = arg, !validate(componentInstantiationArg: arg, and: rootArg) {
+                    return .failure(componentName)
+                }
+            }
+        }
+
+        return .success
+    }
+
+    // MARK: - Private
+
+    private let fileContent: String
+    private let componentNames: Set<String>
 
     private func validate(componentInstantiationArg arg: String, and rootArg: String?) -> Bool {
         return arg == "self" || arg == "self)" || arg == "self," || rootArg == "BootstrapComponent()"

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentInstantiationValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentInstantiationValidatorTests.swift
@@ -14,16 +14,25 @@
 //  limitations under the License.
 //
 
+import Concurrency
 import SourceKittenFramework
 import XCTest
 @testable import NeedleFramework
 
 class ComponentInstantiationValidatorTests: AbstractParserTests {
 
+    private var executor: SequenceExecutor!
+
+    override func setUp() {
+        super.setUp()
+
+        executor = MockSequenceExecutor()
+    }
+
     func test_withValidInstantiations_verifyNoError() {
         let content = self.content(of: "ValidInits.swift")
         let components = [astComponent(withName: "MyComponent"), astComponent(withName: "My1Component"), astComponent(withName: "MyComponent2"), astComponent(withName: "MyCompo3nent"), astComponent(withName: "RootComponent")]
-        let validator = ComponentInstantiationValidator(components: components, fileContents: [content])
+        let validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
         do {
             try validator.process()
         } catch {
@@ -34,7 +43,7 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
     func test_withInvalidInstantiations_verifyErrors() {
         var content = self.content(of: "InvalidInits/InvalidInits1.swift")
         let components = [astComponent(withName: "MyComponent"), astComponent(withName: "MyComponent2"), astComponent(withName: "My5Component"), astComponent(withName: "MyComp6onent6"), astComponent(withName: "RootComponent")]
-        var validator = ComponentInstantiationValidator(components: components, fileContents: [content])
+        var validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -43,7 +52,7 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
         }
 
         content = self.content(of: "InvalidInits/InvalidInits2.swift")
-        validator = ComponentInstantiationValidator(components: components, fileContents: [content])
+        validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -52,7 +61,7 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
         }
 
         content = self.content(of: "InvalidInits/InvalidInits3.swift")
-        validator = ComponentInstantiationValidator(components: components, fileContents: [content])
+        validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -61,7 +70,7 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
         }
 
         content = self.content(of: "InvalidInits/InvalidInits4.swift")
-        validator = ComponentInstantiationValidator(components: components, fileContents: [content])
+        validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -73,7 +82,7 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
     func test_withInvalidInstantiations_notAComponent_verifyNoError() {
         let content = self.content(of: "InvalidInits/InvalidInits1.swift")
         let components = [astComponent(withName: "ADifferentComponent")]
-        let validator = ComponentInstantiationValidator(components: components, fileContents: [content])
+        let validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
         do {
             try validator.process()
         } catch {

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
@@ -37,8 +37,6 @@ class DependencyGraphParserTests: AbstractParserTests {
                 producerCount += 1
             } else if task is ASTParserTask {
                 parserCount += 1
-            } else {
-                XCTFail()
             }
         }
 
@@ -50,7 +48,7 @@ class DependencyGraphParserTests: AbstractParserTests {
             XCTFail("\(error)")
         }
 
-        XCTAssertEqual(executor.executeCallCount, files.count)
+        XCTAssertEqual(executor.executeCallCount, files.count * 2)
         XCTAssertEqual(filterCount, files.count)
         XCTAssertEqual(producerCount, 8)
         XCTAssertEqual(parserCount, 8)
@@ -77,7 +75,7 @@ class DependencyGraphParserTests: AbstractParserTests {
             XCTFail("\(error)")
         }
 
-        XCTAssertEqual(executor.executeCallCount, files.count)
+        XCTAssertEqual(executor.executeCallCount, files.count * 2)
     }
 
     func test_parse_withInvalidComponentInits_verifyError() {

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
@@ -37,8 +37,6 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
                 producerCount += 1
             } else if task is PluginizedASTParserTask {
                 parserCount += 1
-            } else {
-                XCTFail()
             }
         }
 
@@ -50,7 +48,7 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
             XCTFail("\(error)")
         }
 
-        XCTAssertEqual(executor.executeCallCount, files.count)
+        XCTAssertEqual(executor.executeCallCount, files.count * 2)
         XCTAssertEqual(filterCount, files.count)
         XCTAssertEqual(producerCount, 11)
         XCTAssertEqual(parserCount, 11)
@@ -78,7 +76,7 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
             XCTFail("\(error)")
         }
 
-        XCTAssertEqual(executor.executeCallCount, files.count)
+        XCTAssertEqual(executor.executeCallCount, files.count * 2)
     }
 
     func test_parse_withInvalidComponentInits_verifyError() {


### PR DESCRIPTION
Since `ComponentInstantiationValidator` runs on a large number of files, validation for each file can be run in parallel to improve performance.

Fixes #235