### PR TITLE
Add support for parsing component extensions

### DIFF
--- a/Generator/Sources/NeedleFramework/Entry/Generator.swift
+++ b/Generator/Sources/NeedleFramework/Entry/Generator.swift
@@ -71,7 +71,7 @@ public class Generator {
     /// - parameter concurrencyLimit: The maximum number of tasks to execute
     /// concurrently. `nil` if no limit is set.
     /// - throws: `GeneratorError`.
-    public final func generate(from sourceRootPaths: [String], withSourcesListFormat sourcesListFormatValue: String? = nil, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, shouldCollectParsingInfo: Bool, parsingTimeout: Double, exportingTimeout: Double, retryParsingOnTimeoutLimit: Int, concurrencyLimit: Int?) throws {
+    public final func generate(from sourceRootPaths: [String], withSourcesListFormat sourcesListFormatValue: String? = nil, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, shouldCollectParsingInfo: Bool, parsingTimeout: TimeInterval, exportingTimeout: TimeInterval, retryParsingOnTimeoutLimit: Int, concurrencyLimit: Int?) throws {
         let processor: ProcessorType = .generateSource(additionalImports: additionalImports, 
                                                        headerDocPath: headerDocPath, 
                                                        destinationPath: destinationPath, 
@@ -121,7 +121,7 @@ public class Generator {
                                           excludingFilesEndingWith exclusionSuffixes: [String], 
                                           excludingFilesWithPaths exclusionPaths: [String],
                                           shouldCollectParsingInfo: Bool, 
-                                          parsingTimeout: Double, 
+                                          parsingTimeout: TimeInterval,
                                           retryParsingOnTimeoutLimit: Int, 
                                           concurrencyLimit: Int?,
                                           rootComponentName: String) throws {
@@ -139,7 +139,7 @@ public class Generator {
 
     // MARK: - Internal
 
-    func generate(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, using executor: SequenceExecutor, withParsingTimeout parsingTimeout: Double, exportingTimeout: Double) throws {
+    func generate(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, using executor: SequenceExecutor, withParsingTimeout parsingTimeout: TimeInterval, exportingTimeout: TimeInterval) throws {
         let parser = DependencyGraphParser()
         let (components, imports) = try parser.parse(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, withTimeout: parsingTimeout)
         let exporter = DependencyGraphExporter()
@@ -149,7 +149,7 @@ public class Generator {
     // MARK: - Private
     
     private enum ProcessorType {
-        case generateSource(additionalImports: [String], headerDocPath: String?, destinationPath: String, exportingTimeout: Double)
+        case generateSource(additionalImports: [String], headerDocPath: String?, destinationPath: String, exportingTimeout: TimeInterval)
         case printDIStructure(rootComponentName: String)
     }
 
@@ -168,7 +168,7 @@ public class Generator {
                                    excludingFilesEndingWith exclusionSuffixes: [String], 
                                    excludingFilesWithPaths exclusionPaths: [String], 
                                    shouldCollectParsingInfo: Bool, 
-                                   parsingTimeout: Double, 
+                                   parsingTimeout: TimeInterval,
                                    retryParsingOnTimeoutLimit: Int, 
                                    concurrencyLimit: Int?,
                                    processorType: ProcessorType) throws {
@@ -221,7 +221,7 @@ public class Generator {
                                   excludingFilesEndingWith exclusionSuffixes: [String], 
                                   excludingFilesWithPaths exclusionPaths: [String], 
                                   withExecutor executor: SequenceExecutor,
-                                  withParsingTimeout parsingTimeout: Double,
+                                  withParsingTimeout parsingTimeout: TimeInterval,
                                   withRootComponentName rootComponentName: String) throws {
         let parser = DependencyGraphParser()
         let (components, _) = try parser.parse(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, withTimeout: parsingTimeout)

--- a/Generator/Sources/NeedleFramework/Entry/PluginizedGenerator.swift
+++ b/Generator/Sources/NeedleFramework/Entry/PluginizedGenerator.swift
@@ -22,7 +22,7 @@ public class PluginizedGenerator: Generator {
 
     // MARK: - Internal
 
-    override func generate(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, using executor: SequenceExecutor, withParsingTimeout parsingTimeout: Double, exportingTimeout: Double) throws {
+    override func generate(from sourceRootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], with additionalImports: [String], _ headerDocPath: String?, to destinationPath: String, using executor: SequenceExecutor, withParsingTimeout parsingTimeout: TimeInterval, exportingTimeout: TimeInterval) throws {
         let parser = PluginizedDependencyGraphParser()
         let (components, pluginizedComponents, imports) = try parser.parse(from: sourceRootUrls, withSourcesListFormat: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, withTimeout: parsingTimeout)
         let exporter = PluginizedDependencyGraphExporter()

--- a/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
@@ -42,7 +42,7 @@ class DependencyGraphExporter {
     /// - throws: `DependencyGraphExporterError.timeout` if computation times out.
     /// - throws: `DependencyGraphExporterError.unableToWriteFile` if the file
     /// write fails.
-    func export(_ components: [Component], with imports: [String], to path: String, using executor: SequenceExecutor, withTimeout timeout: Double, include headerDocPath: String?) throws {
+    func export(_ components: [Component], with imports: [String], to path: String, using executor: SequenceExecutor, withTimeout timeout: TimeInterval, include headerDocPath: String?) throws {
         // Enqueue tasks.
         let taskHandleTuples = enqueueExportDependencyProviders(for: components, using: executor)
         let headerDocContentHandle = try enqueueLoadHeaderDoc(from: headerDocPath, using: executor)
@@ -91,7 +91,7 @@ class DependencyGraphExporter {
         return taskHandleTuples
     }
 
-    private func awaitSerialization(using taskHandleTuples: [(SequenceExecutionHandle<[SerializedProvider]>, String)], withTimeout timeout: Double) throws -> [SerializedProvider] {
+    private func awaitSerialization(using taskHandleTuples: [(SequenceExecutionHandle<[SerializedProvider]>, String)], withTimeout timeout: TimeInterval) throws -> [SerializedProvider] {
         // Wait for all the generation to complete so we can write all the output into a single file
         var providers = [SerializedProvider]()
         for (taskHandle, componentName) in taskHandleTuples {

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyGraphExporter.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyGraphExporter.swift
@@ -42,7 +42,7 @@ class PluginizedDependencyGraphExporter {
     /// - throws: `DependencyGraphExporterError.timeout` if computation times out.
     /// - throws: `DependencyGraphExporterError.unableToWriteFile` if the file
     /// write fails.
-    func export(_ components: [Component], _ pluginizedComponents: [PluginizedComponent], with imports: [String], to path: String, using executor: SequenceExecutor, withTimeout timeout: Double, include headerDocPath: String?) throws {
+    func export(_ components: [Component], _ pluginizedComponents: [PluginizedComponent], with imports: [String], to path: String, using executor: SequenceExecutor, withTimeout timeout: TimeInterval, include headerDocPath: String?) throws {
         // Enqueue tasks.
         let dependencyProviderHandleTuples = enqueueExportDependencyProviders(for: components, pluginizedComponents, using: executor)
         let pluginExtensionHandleTuples = enqueueExportPluginExtensions(for: pluginizedComponents, using: executor)
@@ -109,7 +109,7 @@ class PluginizedDependencyGraphExporter {
         return taskHandleTuples
     }
 
-    private func awaitSerialization(using taskHandleTuples: [(SequenceExecutionHandle<[SerializedProvider]>, String)], withTimeout timeout: Double) throws -> [SerializedProvider] {
+    private func awaitSerialization(using taskHandleTuples: [(SequenceExecutionHandle<[SerializedProvider]>, String)], withTimeout timeout: TimeInterval) throws -> [SerializedProvider] {
         var providers = [SerializedProvider]()
         for (taskHandle, componentName) in taskHandleTuples {
             do {

--- a/Generator/Sources/NeedleFramework/Models/Component.swift
+++ b/Generator/Sources/NeedleFramework/Models/Component.swift
@@ -40,9 +40,9 @@ class ASTComponent {
     /// The name of the component's dependency protocol.
     let dependencyProtocolName: String
     /// A list of properties this component instantiates, thereby provides.
-    let properties: [Property]
+    var properties: [Property]
     /// A list of expression call type names.
-    let expressionCallTypeNames: [String]
+    var expressionCallTypeNames: [String]
     /// The mutable list of parents.
     var parents = [ASTComponent]()
     /// The referenced dependency protocol data model.

--- a/Generator/Sources/NeedleFramework/Models/ComponentExtensionNode.swift
+++ b/Generator/Sources/NeedleFramework/Models/ComponentExtensionNode.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A data model representing a list of `Component` extensions parsed
+/// from a single file.
+struct ComponentExtensionNode {
+    /// The list of component extensions in this node.
+    let extensions: [ASTComponentExtension]
+    /// The list of import statements including the `import` keyword.
+    let imports: [String]
+}

--- a/Generator/Sources/NeedleFramework/Parsing/AbstractDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/AbstractDependencyGraphParser.swift
@@ -1,0 +1,201 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Concurrency
+import Foundation
+
+/// Errors that can occur during parsing of the dependency graph from
+/// Swift sources.
+enum DependencyGraphParserError: Error {
+    /// Parsing a particular source file timed out. The associated values
+    /// are the path of the file being parsed and the ID of the task that
+    /// was being executed when the timeout occurred.
+    case timeout(String, Int)
+}
+
+/// The base implementation of parsing a set of Swift source files for
+/// dependency graph models.
+class AbstractDependencyGraphParser {
+
+    /// Execute a set of tasks on the files within the given root URLs
+    /// and return their execution handles.
+    ///
+    /// - parameter rootUrls: The URLs of the directories to scan from.
+    /// - parameter sourcesListFormatValue: The optional `String` value of
+    /// the format used by the sources list file. If `nil` and the the given
+    /// `rootUrl` is a file containing a list of Swift source paths, the
+    /// `SourcesListFileFormat.newline` format is used. If the given `rootUrl`
+    /// is not a file containing a list of Swift source paths, this value is
+    /// ignored.
+    /// - parameter execution: The logic to invoke for each file.
+    /// - returns: The set of execution handles returned by the given logic
+    /// closure and their corresponding file URLs.
+    /// - throws: If any error occurred during execution.
+    func executeAndCollectTaskHandles<ResultType>(with rootUrls: [URL], sourcesListFormatValue: String?, execution: (URL) -> SequenceExecutionHandle<ResultType>) throws -> [(SequenceExecutionHandle<ResultType>, URL)] {
+        var urlHandles = [(SequenceExecutionHandle<ResultType>, URL)]()
+
+        // Enumerate all files and execute parsing sequences concurrently.
+        let enumerator = FileEnumerator()
+        for url in rootUrls {
+            try enumerator.enumerate(from: url, withSourcesListFormat: sourcesListFormatValue) { (fileUrl: URL) in
+                let taskHandle = execution(fileUrl)
+                urlHandles.append((taskHandle, fileUrl))
+            }
+        }
+
+        return urlHandles
+    }
+
+    // MARK: - Extension Parsing
+
+    /// Parse source files in directories specified by the given root URLs
+    /// for component extension data models.
+    ///
+    /// - parameter rootUrls: The URLs of the directories to scan from.
+    /// - parameter sourcesListFormatValue: The optional `String` value of
+    /// the format used by the sources list file. If `nil` and the the given
+    /// `rootUrl` is a file containing a list of Swift source paths, the
+    /// `SourcesListFileFormat.newline` format is used. If the given `rootUrl`
+    /// is not a file containing a list of Swift source paths, this value is
+    /// ignored.
+    /// - parameter exclusionSuffixes: The list of file name suffixes to
+    /// check from. If a filename's suffix matches any in the this list,
+    /// the file will not be parsed.
+    /// - parameter exclusionPaths: The list of path components to check.
+    /// If a file's URL path contains any elements in this list, the file
+    /// will not be parsed.
+    /// - parameter parsedComponents: The components that are parsed out
+    /// from declarations, whose extensions this method parses.
+    /// - parameter executor: The executor to use for concurrent processing
+    /// of files.
+    /// - parameter timeout: The timeout value, in seconds, to use for
+    /// waiting on parsing tasks.
+    /// - returns: The list of component extensions for parsed components
+    /// and their import statements.
+    /// - throws: If any error occurred during execution.
+    func parseAndCollectComponentExtensionDataModels(with rootUrls: [URL], sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], parsedComponents: [ASTComponent], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> ([ASTComponentExtension], Set<String>) {
+        let componentExtensionUrlHandles: [ComponentExtensionsUrlSequenceHandle] = try enqueueExtensionParsingTasks(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, parsedComponents: parsedComponents, using: executor)
+        return try collectExtensionDataModels(with: componentExtensionUrlHandles, waitUpTo: timeout)
+    }
+
+    private func enqueueExtensionParsingTasks(with rootUrls: [URL], sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], parsedComponents: [ASTComponent], using executor: SequenceExecutor) throws -> [ComponentExtensionsUrlSequenceHandle] {
+        return try executeAndCollectTaskHandles(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue) { (fileUrl: URL) -> SequenceExecutionHandle<ComponentExtensionNode> in
+            let task = ComponentExtensionsFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths, components: parsedComponents)
+            return executor.executeSequence(from: task) { (currentTask: Task, currentResult: Any) -> SequenceExecution<ComponentExtensionNode> in
+                if currentTask is ComponentExtensionsFilterTask, let filterResult = currentResult as? FilterResult {
+                    switch filterResult {
+                    case .shouldProcess(let url, let content):
+                        return .continueSequence(ASTProducerTask(sourceUrl: url, sourceContent: content))
+                    case .skip:
+                        return .endOfSequence(ComponentExtensionNode(extensions: [], imports: []))
+                    }
+                } else if currentTask is ASTProducerTask, let ast = currentResult as? AST {
+                    return .continueSequence(ComponentExtensionsParserTask(ast: ast, components: parsedComponents))
+                } else if currentTask is ComponentExtensionsParserTask, let node = currentResult as? ComponentExtensionNode {
+                    return .endOfSequence(node)
+                } else {
+                    fatalError("Unhandled task \(currentTask) with result \(currentResult)")
+                }
+            }
+        }
+    }
+
+    private func collectExtensionDataModels(with urlHandles: [ComponentExtensionsUrlSequenceHandle], waitUpTo timeout: TimeInterval) throws -> ([ASTComponentExtension], Set<String>) {
+        var extensions = [ASTComponentExtension]()
+        var imports = Set<String>()
+        for urlHandle in urlHandles {
+            do {
+                let node = try urlHandle.handle.await(withTimeout: timeout)
+                extensions.append(contentsOf: node.extensions)
+                for statement in node.imports {
+                    imports.insert(statement)
+                }
+            } catch SequenceExecutionError.awaitTimeout(let taskId) {
+                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
+            } catch {
+                throw error
+            }
+        }
+        return (extensions, imports)
+    }
+
+    // MARK: - Component Initializer Parsing
+
+    /// Collect all the source file contents that contain component
+    /// instantiations from the given root URLs.
+    ///
+    /// - parameter rootUrls: The URLs of the directories to scan from.
+    /// - parameter sourcesListFormatValue: The optional `String` value of
+    /// the format used by the sources list file. If `nil` and the the given
+    /// `rootUrl` is a file containing a list of Swift source paths, the
+    /// `SourcesListFileFormat.newline` format is used. If the given `rootUrl`
+    /// is not a file containing a list of Swift source paths, this value is
+    /// ignored.
+    /// - parameter exclusionSuffixes: The list of file name suffixes to
+    /// check from. If a filename's suffix matches any in the this list,
+    /// the file will not be parsed.
+    /// - parameter exclusionPaths: The list of path components to check.
+    /// If a file's URL path contains any elements in this list, the file
+    /// will not be parsed.
+    /// - parameter executor: The executor to use for concurrent processing
+    /// of files.
+    /// - parameter timeout: The timeout value, in seconds, to use for
+    /// waiting on parsing tasks.
+    /// - returns: The source file contents.
+    /// - throws: If any error occurred during execution.
+    func sourceContentsContainComponentInstantiations(with rootUrls: [URL], sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> [String] {
+        let initsUrlHandles = try enqueueComponentInitsTasks(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor)
+        return try collectInitsDataModels(with: initsUrlHandles, waitUpTo: timeout)
+    }
+
+    private func enqueueComponentInitsTasks(with rootUrls: [URL], sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], using executor: SequenceExecutor) throws -> [ComponentInitsUrlSequenceHandle] {
+        return try executeAndCollectTaskHandles(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue) { (fileUrl: URL) -> SequenceExecutionHandle<String?> in
+            let task = ComponentInitsFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths)
+            return executor.executeSequence(from: task) { (currentTask: Task, currentResult: Any) -> SequenceExecution<String?> in
+                if currentTask is ComponentInitsFilterTask, let filterResult = currentResult as? FilterResult {
+                    switch filterResult {
+                    case .shouldProcess(_, let content):
+                        return .endOfSequence(content)
+                    case .skip:
+                        return .endOfSequence(nil)
+                    }
+                } else {
+                    fatalError("Unhandled task \(currentTask) with result \(currentResult)")
+                }
+            }
+        }
+    }
+
+    private func collectInitsDataModels(with urlHandles: [ComponentInitsUrlSequenceHandle], waitUpTo timeout: TimeInterval) throws -> [String] {
+        var sourceContents = [String]()
+        for urlHandle in urlHandles {
+            do {
+                let content = try urlHandle.handle.await(withTimeout: timeout)
+                if let content = content {
+                    sourceContents.append(content)
+                }
+            } catch SequenceExecutionError.awaitTimeout(let taskId) {
+                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
+            } catch {
+                throw error
+            }
+        }
+        return sourceContents
+    }
+}
+
+private typealias ComponentExtensionsUrlSequenceHandle = (handle: SequenceExecutionHandle<ComponentExtensionNode>, fileUrl: URL)
+private typealias ComponentInitsUrlSequenceHandle = (handle: SequenceExecutionHandle<String?>, fileUrl: URL)

--- a/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
@@ -17,19 +17,10 @@
 import Concurrency
 import Foundation
 
-/// Errors that can occur during parsing of the dependency graph from
-/// Swift sources.
-enum DependencyGraphParserError: Error {
-    /// Parsing a particular source file timed out. The associated values
-    /// are the path of the file being parsed and the ID of the task that
-    /// was being executed when the timeout occurred.
-    case timeout(String, Int)
-}
-
 /// The entry utility for the parsing phase. The parser deeply scans a
 /// directory and parses the relevant Swift source files, and finally
 /// outputs the dependency graph.
-class DependencyGraphParser {
+class DependencyGraphParser: AbstractDependencyGraphParser {
 
     /// Parse all the Swift sources within the directories of given URLs,
     /// excluding any file that contains a suffix specified in the given
@@ -56,34 +47,20 @@ class DependencyGraphParser {
     /// statements.
     /// - throws: `DependencyGraphParserError.timeout` if parsing a Swift
     /// source timed out.
-    func parse(from rootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String] = [], excludingFilesWithPaths exclusionPaths: [String] = [], using executor: SequenceExecutor, withTimeout timeout: Double) throws -> (components: [Component], imports: [String]) {
+    func parse(from rootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String] = [], excludingFilesWithPaths exclusionPaths: [String] = [], using executor: SequenceExecutor, withTimeout timeout: TimeInterval) throws -> (components: [Component], imports: [String]) {
         // Collect data models for component and dependency declarations.
         let dependencyNodeUrlHandles: [DependencyNodeUrlSequenceHandle] = try enqueueDeclarationParsingTasks(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor)
         let (components, dependencies, imports) = try collectDeclarationDataModels(with: dependencyNodeUrlHandles, waitUpTo: timeout)
 
+        // Collect data models for component extensions.
+        let (componentExtensions, extensionImports) = try parseAndCollectComponentExtensionDataModels(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, parsedComponents: components, using: executor, with: timeout)
+        let allImports = imports.union(extensionImports)
+
         // Collect source contents that contain component instantiations for validation.
-        let initsUrlHandles = try enqueueComponentInitsTasks(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor)
-        let initsSourceContents = try collectInitsDataModels(with: initsUrlHandles, waitUpTo: timeout)
+        let initsSourceContents = try sourceContentsContainComponentInstantiations(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, with: timeout)
 
         // Process all the data models.
-        return try process(components, dependencies, imports, initsSourceContents, with: executor, timeout)
-    }
-
-    // MARK: - Common
-
-    private func executeAndCollectTaskHandles<ResultType>(with rootUrls: [URL], sourcesListFormatValue: String?, execution: (URL) -> SequenceExecutionHandle<ResultType>) throws -> [(SequenceExecutionHandle<ResultType>, URL)] {
-        var urlHandles = [(SequenceExecutionHandle<ResultType>, URL)]()
-
-        // Enumerate all files and execute parsing sequences concurrently.
-        let enumerator = FileEnumerator()
-        for url in rootUrls {
-            try enumerator.enumerate(from: url, withSourcesListFormat: sourcesListFormatValue) { (fileUrl: URL) in
-                let taskHandle = execution(fileUrl)
-                urlHandles.append((taskHandle, fileUrl))
-            }
-        }
-
-        return urlHandles
+        return try process(components, with: componentExtensions, dependencies, allImports, validate: initsSourceContents, using: executor, with: timeout)
     }
 
     // MARK: - Declaration Parsing
@@ -112,7 +89,7 @@ class DependencyGraphParser {
         }
     }
 
-    private func collectDeclarationDataModels(with urlHandles: [DependencyNodeUrlSequenceHandle], waitUpTo timeout: Double) throws -> ([ASTComponent], [Dependency], Set<String>) {
+    private func collectDeclarationDataModels(with urlHandles: [DependencyNodeUrlSequenceHandle], waitUpTo timeout: TimeInterval) throws -> ([ASTComponent], [Dependency], Set<String>) {
         var components = [ASTComponent]()
         var dependencies = [Dependency]()
         var imports = Set<String>()
@@ -133,48 +110,12 @@ class DependencyGraphParser {
         return (components, dependencies, imports)
     }
 
-    // MARK: - Component Initializer Parsing
-
-    private func enqueueComponentInitsTasks(with rootUrls: [URL], sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], using executor: SequenceExecutor) throws -> [ComponentInitsUrlSequenceHandle] {
-        return try executeAndCollectTaskHandles(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue) { (fileUrl: URL) -> SequenceExecutionHandle<String?> in
-            let task = ComponentInitsFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths)
-            return executor.executeSequence(from: task) { (currentTask: Task, currentResult: Any) -> SequenceExecution<String?> in
-                if currentTask is ComponentInitsFilterTask, let filterResult = currentResult as? FilterResult {
-                    switch filterResult {
-                    case .shouldProcess(_, let content):
-                        return .endOfSequence(content)
-                    case .skip:
-                        return .endOfSequence(nil)
-                    }
-                } else {
-                    fatalError("Unhandled task \(currentTask) with result \(currentResult)")
-                }
-            }
-        }
-    }
-
-    private func collectInitsDataModels(with urlHandles: [ComponentInitsUrlSequenceHandle], waitUpTo timeout: Double) throws -> [String] {
-        var sourceContents = [String]()
-        for urlHandle in urlHandles {
-            do {
-                let content = try urlHandle.handle.await(withTimeout: timeout)
-                if let content = content {
-                    sourceContents.append(content)
-                }
-            } catch SequenceExecutionError.awaitTimeout(let taskId) {
-                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
-            } catch {
-                throw error
-            }
-        }
-        return sourceContents
-    }
-
     // MARK: - Processing
 
-    private func process(_ components: [ASTComponent], _ dependencies: [Dependency], _ imports: Set<String>, _ initsSourceContents: [String], with executor: SequenceExecutor, _ timeout: Double) throws -> ([Component], [String]) {
+    private func process(_ components: [ASTComponent], with componentExtensions: [ASTComponentExtension], _ dependencies: [Dependency], _ imports: Set<String>, validate initsSourceContents: [String], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> ([Component], [String]) {
         let processors: [Processor] = [
             DuplicateValidator(components: components, dependencies: dependencies),
+            ComponentConsolidator(components: components, componentExtensions: componentExtensions),
             ParentLinker(components: components),
             DependencyLinker(components: components, dependencies: dependencies),
             AncestorCycleValidator(components: components),
@@ -193,4 +134,3 @@ class DependencyGraphParser {
 }
 
 private typealias DependencyNodeUrlSequenceHandle = (handle: SequenceExecutionHandle<DependencyGraphNode>, fileUrl: URL)
-private typealias ComponentInitsUrlSequenceHandle = (handle: SequenceExecutionHandle<String?>, fileUrl: URL)

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
@@ -20,7 +20,7 @@ import Foundation
 /// The entry utility for the parsing phase. The parser deeply scans a
 /// directory and parses the relevant Swift source files, and finally
 /// outputs the dependency graph.
-class PluginizedDependencyGraphParser {
+class PluginizedDependencyGraphParser: AbstractDependencyGraphParser {
 
     /// Parse all the Swift sources within the directories of given URLs,
     /// excluding any file that contains a suffix specified in the given
@@ -47,33 +47,20 @@ class PluginizedDependencyGraphParser {
     /// data models and sorted import statements.
     /// - throws: `DependencyGraphParserError.timeout` if parsing a Swift
     /// source timed out.
-    func parse(from rootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String] = [], excludingFilesWithPaths exclusionPaths: [String] = [], using executor: SequenceExecutor, withTimeout timeout: Double) throws -> ([Component], [PluginizedComponent], [String]) {
+    func parse(from rootUrls: [URL], withSourcesListFormat sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String] = [], excludingFilesWithPaths exclusionPaths: [String] = [], using executor: SequenceExecutor, withTimeout timeout: TimeInterval) throws -> ([Component], [PluginizedComponent], [String]) {
         // Collect data models for component and dependency declarations.
         let urlHandles: [DependencyNodeUrlSequenceHandle] = try enqueueDeclarationParsingTasks(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor)
-        let (pluginizedComponents, nonCoreComponents, pluginExtensions, components, dependencies, imports) = try collectDataModels(with: urlHandles, waitUpTo: timeout)
+        let (pluginizedComponents, nonCoreComponents, pluginExtensions, regularComponents, dependencies, imports) = try collectDataModels(with: urlHandles, waitUpTo: timeout)
+
+        // Collect data models for component extensions.
+        let allComponents = commonComponentModel(of: pluginizedComponents, regularComponents: nonCoreComponents + regularComponents)
+        let (componentExtensions, extensionImports) = try parseAndCollectComponentExtensionDataModels(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, parsedComponents: allComponents, using: executor, with: timeout)
+        let allImports = imports.union(extensionImports)
 
         // Collect source contents that contain component instantiations for validation.
-        let initsUrlHandles = try enqueueComponentInitsTasks(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor)
-        let initsSourceContents = try collectInitsDataModels(with: initsUrlHandles, waitUpTo: timeout)
+        let initsSourceContents = try sourceContentsContainComponentInstantiations(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, with: timeout)
 
-        return try process(pluginizedComponents, nonCoreComponents, pluginExtensions, components, dependencies, imports, initsSourceContents, with: executor, timeout)
-    }
-
-    // MARK: - Common
-
-    private func executeAndCollectTaskHandles<ResultType>(with rootUrls: [URL], sourcesListFormatValue: String?, execution: (URL) -> SequenceExecutionHandle<ResultType>) throws -> [(SequenceExecutionHandle<ResultType>, URL)] {
-        var urlHandles = [(SequenceExecutionHandle<ResultType>, URL)]()
-
-        // Enumerate all files and execute parsing sequences concurrently.
-        let enumerator = FileEnumerator()
-        for url in rootUrls {
-            try enumerator.enumerate(from: url, withSourcesListFormat: sourcesListFormatValue) { (fileUrl: URL) in
-                let taskHandle = execution(fileUrl)
-                urlHandles.append((taskHandle, fileUrl))
-            }
-        }
-
-        return urlHandles
+        return try process(pluginizedComponents: pluginizedComponents, nonCoreComponents: nonCoreComponents, regularComponents: regularComponents, with: pluginExtensions, componentExtensions, dependencies, allImports, validate: initsSourceContents, using: executor, with: timeout)
     }
 
     // MARK: - Declaration Parsing
@@ -102,7 +89,7 @@ class PluginizedDependencyGraphParser {
         }
     }
 
-    private func collectDataModels(with urlHandles: [DependencyNodeUrlSequenceHandle], waitUpTo timeout: Double) throws -> ([PluginizedASTComponent], [ASTComponent], [PluginExtension], [ASTComponent], [Dependency], Set<String>) {
+    private func collectDataModels(with urlHandles: [DependencyNodeUrlSequenceHandle], waitUpTo timeout: TimeInterval) throws -> ([PluginizedASTComponent], [ASTComponent], [PluginExtension], [ASTComponent], [Dependency], Set<String>) {
         var pluginizedComponents = [PluginizedASTComponent]()
         var nonCoreComponents = [ASTComponent]()
         var pluginExtensions = [PluginExtension]()
@@ -129,53 +116,13 @@ class PluginizedDependencyGraphParser {
         return (pluginizedComponents, nonCoreComponents, pluginExtensions, components, dependencies, imports)
     }
 
-    // MARK: - Component Initializer Parsing
-
-    private func enqueueComponentInitsTasks(with rootUrls: [URL], sourcesListFormatValue: String?, excludingFilesEndingWith exclusionSuffixes: [String], excludingFilesWithPaths exclusionPaths: [String], using executor: SequenceExecutor) throws -> [ComponentInitsUrlSequenceHandle] {
-        return try executeAndCollectTaskHandles(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue) { (fileUrl: URL) -> SequenceExecutionHandle<String?> in
-            let task = ComponentInitsFilterTask(url: fileUrl, exclusionSuffixes: exclusionSuffixes, exclusionPaths: exclusionPaths)
-            return executor.executeSequence(from: task) { (currentTask: Task, currentResult: Any) -> SequenceExecution<String?> in
-                if currentTask is ComponentInitsFilterTask, let filterResult = currentResult as? FilterResult {
-                    switch filterResult {
-                    case .shouldProcess(_, let content):
-                        return .endOfSequence(content)
-                    case .skip:
-                        return .endOfSequence(nil)
-                    }
-                } else {
-                    fatalError("Unhandled task \(currentTask) with result \(currentResult)")
-                }
-            }
-        }
-    }
-
-    private func collectInitsDataModels(with urlHandles: [ComponentInitsUrlSequenceHandle], waitUpTo timeout: Double) throws -> [String] {
-        var sourceContents = [String]()
-        for urlHandle in urlHandles {
-            do {
-                let content = try urlHandle.handle.await(withTimeout: timeout)
-                if let content = content {
-                    sourceContents.append(content)
-                }
-            } catch SequenceExecutionError.awaitTimeout(let taskId) {
-                throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)
-            } catch {
-                throw error
-            }
-        }
-        return sourceContents
-    }
-
     // MARK: - Processing
 
-    private func process(_ pluginizedComponents: [PluginizedASTComponent], _ nonCoreComponents: [ASTComponent], _ pluginExtensions: [PluginExtension], _ components: [ASTComponent], _ dependencies: [Dependency], _ imports: Set<String>, _ initsSourceContents: [String], with executor: SequenceExecutor, _ timeout: Double) throws -> ([Component], [PluginizedComponent], [String]) {
-        var allComponents = nonCoreComponents + components
-        let pluginizedComponentData = pluginizedComponents.map { (component: PluginizedASTComponent) -> ASTComponent in
-            component.data
-        }
-        allComponents.append(contentsOf: pluginizedComponentData)
+    private func process(pluginizedComponents: [PluginizedASTComponent], nonCoreComponents: [ASTComponent], regularComponents: [ASTComponent], with pluginExtensions: [PluginExtension], _ componentExtensions: [ASTComponentExtension], _ dependencies: [Dependency], _ imports: Set<String>, validate initsSourceContents: [String], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> ([Component], [PluginizedComponent], [String]) {
+        let allComponents = commonComponentModel(of: pluginizedComponents, regularComponents: nonCoreComponents + regularComponents)
         let processors: [Processor] = [
             DuplicateValidator(components: allComponents, dependencies: dependencies),
+            ComponentConsolidator(components: allComponents, componentExtensions: componentExtensions),
             ParentLinker(components: allComponents),
             DependencyLinker(components: allComponents, dependencies: dependencies),
             NonCoreComponentLinker(pluginizedComponents: pluginizedComponents, nonCoreComponents: nonCoreComponents),
@@ -189,7 +136,7 @@ class PluginizedDependencyGraphParser {
         }
 
         // Return back non-core components as well since they can be treated as any regular component.
-        let valueTypeComponents = (components + nonCoreComponents).map { (astComponent: ASTComponent) -> Component in
+        let valueTypeComponents = (regularComponents + nonCoreComponents).map { (astComponent: ASTComponent) -> Component in
             astComponent.valueType
         }
         let valueTypePluginizedComponents = pluginizedComponents.map { (astComponent: PluginizedASTComponent) -> PluginizedComponent in
@@ -198,7 +145,13 @@ class PluginizedDependencyGraphParser {
         let sortedImports = imports.sorted()
         return (valueTypeComponents, valueTypePluginizedComponents, sortedImports)
     }
+
+    private func commonComponentModel(of pluginizedComponents: [PluginizedASTComponent], regularComponents: [ASTComponent]) -> [ASTComponent] {
+        let pluginizedComponentData = pluginizedComponents.map { (component: PluginizedASTComponent) -> ASTComponent in
+            component.data
+        }
+        return regularComponents + pluginizedComponentData
+    }
 }
 
 private typealias DependencyNodeUrlSequenceHandle = (handle: SequenceExecutionHandle<PluginizedDependencyGraphNode>, fileUrl: URL)
-private typealias ComponentInitsUrlSequenceHandle = (handle: SequenceExecutionHandle<String?>, fileUrl: URL)

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/ComponentConsolidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/ComponentConsolidator.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A post processing utility class that consolidates component extensions
+/// with the corresponding components.
+class ComponentConsolidator: Processor {
+
+    /// Initializer.
+    ///
+    /// - parameter components: The components to consolidate into.
+    /// - parameter componentExtensions: The component extensions to
+    /// consolidate with.
+    init(components: [ASTComponent], componentExtensions: [ASTComponentExtension]) {
+        self.components = components
+        self.componentExtensions = componentExtensions
+    }
+
+    /// Process the data models.
+    func process() throws {
+        let nameToComponent = components.createDictionary { (component: ASTComponent) -> (String, ASTComponent) in
+            (component.name, component)
+        }
+        for componentExtension in componentExtensions {
+            let component = nameToComponent[componentExtension.name]
+            if let component = component {
+                component.properties.append(contentsOf: componentExtension.properties)
+                component.expressionCallTypeNames.append(contentsOf: componentExtension.expressionCallTypeNames)
+            } else {
+                throw GeneratorError.withMessage("\(componentExtension.name) only has extension but missing declaration.")
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private let components: [ASTComponent]
+    private let componentExtensions: [ASTComponentExtension]
+}

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/ComponentInstantiationValidator.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/ComponentInstantiationValidator.swift
@@ -29,7 +29,7 @@ class ComponentInstantiationValidator: Processor {
     /// tasks.
     /// - parameter timeout: The timeout value to use to wait for each
     /// individual validations.
-    init(components: [ASTComponent], fileContents: [String], executor: SequenceExecutor, timeout: Double) {
+    init(components: [ASTComponent], fileContents: [String], executor: SequenceExecutor, timeout: TimeInterval) {
         self.componentNames = Set(components.map({ (component: ASTComponent) -> String in
             component.name
         }))
@@ -70,7 +70,7 @@ class ComponentInstantiationValidator: Processor {
     private let componentNames: Set<String>
     private let fileContents: [String]
     private let executor: SequenceExecutor
-    private let timeout: Double
+    private let timeout: TimeInterval
 }
 
 private enum ComponentInstantiationValidationResult {

--- a/Generator/Sources/NeedleFramework/Parsing/Processors/ParentLinker.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Processors/ParentLinker.swift
@@ -28,9 +28,8 @@ class ParentLinker: Processor {
 
     /// Process the data models.
     func process() throws {
-        var nameToComponent = [String: ASTComponent]()
-        for component in components {
-            nameToComponent[component.name] = component
+        let nameToComponent = components.createDictionary { (component: ASTComponent) -> (String, ASTComponent) in
+            (component.name, component)
         }
         for component in components {
             for typeName in component.expressionCallTypeNames {

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ComponentExtensionsParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ComponentExtensionsParserTask.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Concurrency
+import Foundation
+import SourceKittenFramework
+
+/// A task that parses Swift AST component extensions into data models.
+class ComponentExtensionsParserTask: AbstractTask<ComponentExtensionNode> {
+
+    /// Initializer.
+    ///
+    /// - parameter ast: The AST of the file to parse.
+    /// - parameter components: All the parsed out components.
+    init(ast: AST, components: [ASTComponent]) {
+        self.ast = ast
+        self.componentNames = components.map { (component: ASTComponent) -> String in
+            component.name
+        }
+        super.init(id: TaskIds.componentExtenionsParserTask.rawValue)
+    }
+
+    /// Execute the task and returns the dependency graph data model.
+    ///
+    /// - returns: Parsed `DependencyGraphNode`.
+    /// - throws: Any error occurred during execution.
+    override func execute() throws -> ComponentExtensionNode {
+        var extensions = [ASTComponentExtension]()
+
+        let substructures = ast.structure.substructures
+        for substructure in substructures {
+            if substructure.isExtension(of: componentNames) {
+                let properties = try substructure.properties()
+                extensions.append(ASTComponentExtension(name: substructure.name, properties: properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames))
+            }
+        }
+        return ComponentExtensionNode(extensions: extensions, imports: ast.imports)
+    }
+
+    // MARK: - Private
+
+    private let ast: AST
+    private let componentNames: [String]
+}
+
+// MARK: - SourceKit AST Parsing Utilities
+
+private extension Structure {
+
+    /// Check if this structure represents a `Component` extension for
+    /// a component with a name in the given list.
+    ///
+    /// - parameter componentNames: The list of component names to check.
+    /// - returns: `true` if this structure is an extension. `false`
+    /// otherwise.
+    func isExtension(of componentNames: [String]) -> Bool {
+        let type = dictionary["key.kind"] as! String
+        if type == "source.lang.swift.decl.extension" {
+            return componentNames.contains(self.name)
+        }
+
+        return false
+    }
+}

--- a/Generator/Sources/NeedleFramework/Utilities/TaskIds.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/TaskIds.swift
@@ -29,6 +29,7 @@ enum TaskIds: Int {
     case astProducerTask = 4
     /// AST parsing task IDs.
     case declarationsParserTask = 5
+    case componentExtenionsParserTask = 15
     case pluginizedDeclarationsParserTask = 6
     /// Dependency provider declaring task ID.
     case dependencyProviderDeclarerTask = 7

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentConsolidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentConsolidatorTests.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import NeedleFramework
+
+class ComponentConsolidatorTests: AbstractParserTests {
+
+    func test_process_withMatchingSets_verifyResults() {
+        let components = [ASTComponent(name: "A", dependencyProtocolName: "", properties: [Property(name: "p1", type: "P1")], expressionCallTypeNames: ["E1"])]
+        let componentExtensions = [ASTComponentExtension(name: "A", properties: [Property(name: "p2", type: "P2")], expressionCallTypeNames: ["E2"])]
+
+        let processor = ComponentConsolidator(components: components, componentExtensions: componentExtensions)
+
+        try! processor.process()
+
+        XCTAssertEqual(components[0].properties, [Property(name: "p1", type: "P1"), Property(name: "p2", type: "P2")])
+        XCTAssertEqual(components[0].expressionCallTypeNames, ["E1", "E2"])
+    }
+
+    func test_process_withNonMatchingSets_verifyError() {
+        let componentExtensions = [ASTComponentExtension(name: "A", properties: [Property(name: "p2", type: "P2")], expressionCallTypeNames: ["E2"])]
+
+        let processor = ComponentConsolidator(components: [], componentExtensions: componentExtensions)
+
+        do {
+            try processor.process()
+
+            XCTFail()
+        } catch {
+            XCTAssertTrue(error is GeneratorError)
+            XCTAssertTrue("\(error)".contains(componentExtensions[0].name))
+        }
+    }
+}

--- a/Sample/MVC/TicTacToe/Sources/LoggedIn/LoggedInComponent.swift
+++ b/Sample/MVC/TicTacToe/Sources/LoggedIn/LoggedInComponent.swift
@@ -23,10 +23,6 @@ class LoggedInComponent: Component<EmptyDependency>, LoggedInBuilder {
         return mutableScoreStream
     }
 
-    var mutableScoreStream: MutableScoreStream {
-        return shared { ScoreStreamImpl() }
-    }
-
     var loggedInViewController: UIViewController {
         return LoggedInViewController(gameBuilder: gameComponent, scoreStream: scoreStream, scoreSheetBuilder: scoreSheetComponent)
     }
@@ -44,4 +40,12 @@ class LoggedInComponent: Component<EmptyDependency>, LoggedInBuilder {
 // this allows LoggedInViewController to be initialized lazily.
 protocol LoggedInBuilder {
     var loggedInViewController: UIViewController { get }
+}
+
+// Use extension to show parsing of component extensions.
+extension LoggedInComponent {
+
+    var mutableScoreStream: MutableScoreStream {
+        return shared { ScoreStreamImpl() }
+    }
 }


### PR DESCRIPTION
Updated TicTacToe sample to use extension for the `LoggedInComponent`.

Also refactored common code between `DependencyGraphParser` and `PluginizedDependencyGraphParser` into base class `AbstractDependencyGraphParser`.

Fixes #148