### PR TITLE
Include file URL in component instantiation errors

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/DependencyGraphParser.swift
@@ -57,10 +57,10 @@ class DependencyGraphParser: AbstractDependencyGraphParser {
         let allImports = imports.union(extensionImports)
 
         // Collect source contents that contain component instantiations for validation.
-        let initsSourceContents = try sourceContentsContainComponentInstantiations(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, with: timeout)
+        let initsSourceUrlContents = try sourceUrlContentsContainComponentInstantiations(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, with: timeout)
 
         // Process all the data models.
-        return try process(components, with: componentExtensions, dependencies, allImports, validate: initsSourceContents, using: executor, with: timeout)
+        return try process(components, with: componentExtensions, dependencies, allImports, validate: initsSourceUrlContents, using: executor, with: timeout)
     }
 
     // MARK: - Declaration Parsing
@@ -112,14 +112,14 @@ class DependencyGraphParser: AbstractDependencyGraphParser {
 
     // MARK: - Processing
 
-    private func process(_ components: [ASTComponent], with componentExtensions: [ASTComponentExtension], _ dependencies: [Dependency], _ imports: Set<String>, validate initsSourceContents: [String], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> ([Component], [String]) {
+    private func process(_ components: [ASTComponent], with componentExtensions: [ASTComponentExtension], _ dependencies: [Dependency], _ imports: Set<String>, validate initsSourceUrlContents: [UrlFileContent], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> ([Component], [String]) {
         let processors: [Processor] = [
             DuplicateValidator(components: components, dependencies: dependencies),
             ComponentConsolidator(components: components, componentExtensions: componentExtensions),
             ParentLinker(components: components),
             DependencyLinker(components: components, dependencies: dependencies),
             AncestorCycleValidator(components: components),
-            ComponentInstantiationValidator(components: components, fileContents: initsSourceContents, executor: executor, timeout: timeout)
+            ComponentInstantiationValidator(components: components, urlFileContents: initsSourceUrlContents, executor: executor, timeout: timeout)
         ]
         for processor in processors {
             try processor.process()

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedDependencyGraphParser.swift
@@ -58,9 +58,9 @@ class PluginizedDependencyGraphParser: AbstractDependencyGraphParser {
         let allImports = imports.union(extensionImports)
 
         // Collect source contents that contain component instantiations for validation.
-        let initsSourceContents = try sourceContentsContainComponentInstantiations(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, with: timeout)
+        let initsSourceUrlContents = try sourceUrlContentsContainComponentInstantiations(with: rootUrls, sourcesListFormatValue: sourcesListFormatValue, excludingFilesEndingWith: exclusionSuffixes, excludingFilesWithPaths: exclusionPaths, using: executor, with: timeout)
 
-        return try process(pluginizedComponents: pluginizedComponents, nonCoreComponents: nonCoreComponents, regularComponents: regularComponents, with: pluginExtensions, componentExtensions, dependencies, allImports, validate: initsSourceContents, using: executor, with: timeout)
+        return try process(pluginizedComponents: pluginizedComponents, nonCoreComponents: nonCoreComponents, regularComponents: regularComponents, with: pluginExtensions, componentExtensions, dependencies, allImports, validate: initsSourceUrlContents, using: executor, with: timeout)
     }
 
     // MARK: - Declaration Parsing
@@ -118,7 +118,7 @@ class PluginizedDependencyGraphParser: AbstractDependencyGraphParser {
 
     // MARK: - Processing
 
-    private func process(pluginizedComponents: [PluginizedASTComponent], nonCoreComponents: [ASTComponent], regularComponents: [ASTComponent], with pluginExtensions: [PluginExtension], _ componentExtensions: [ASTComponentExtension], _ dependencies: [Dependency], _ imports: Set<String>, validate initsSourceContents: [String], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> ([Component], [PluginizedComponent], [String]) {
+    private func process(pluginizedComponents: [PluginizedASTComponent], nonCoreComponents: [ASTComponent], regularComponents: [ASTComponent], with pluginExtensions: [PluginExtension], _ componentExtensions: [ASTComponentExtension], _ dependencies: [Dependency], _ imports: Set<String>, validate initsSourceUrlContents: [UrlFileContent], using executor: SequenceExecutor, with timeout: TimeInterval) throws -> ([Component], [PluginizedComponent], [String]) {
         let allComponents = commonComponentModel(of: pluginizedComponents, regularComponents: nonCoreComponents + regularComponents)
         let processors: [Processor] = [
             DuplicateValidator(components: allComponents, dependencies: dependencies),
@@ -129,7 +129,7 @@ class PluginizedDependencyGraphParser: AbstractDependencyGraphParser {
             PluginExtensionLinker(pluginizedComponents: pluginizedComponents, pluginExtensions: pluginExtensions),
             AncestorCycleValidator(components: allComponents),
             PluginExtensionCycleValidator(pluginizedComponents: pluginizedComponents),
-            ComponentInstantiationValidator(components: allComponents, fileContents: initsSourceContents, executor: executor, timeout: timeout)
+            ComponentInstantiationValidator(components: allComponents, urlFileContents: initsSourceUrlContents, executor: executor, timeout: timeout)
         ]
         for processor in processors {
             try processor.process()

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentInstantiationValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentInstantiationValidatorTests.swift
@@ -30,9 +30,9 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
     }
 
     func test_withValidInstantiations_verifyNoError() {
-        let content = self.content(of: "ValidInits.swift")
+        let urlContent = self.urlContent(of: "ValidInits.swift")
         let components = [astComponent(withName: "MyComponent"), astComponent(withName: "My1Component"), astComponent(withName: "MyComponent2"), astComponent(withName: "MyCompo3nent"), astComponent(withName: "RootComponent")]
-        let validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
+        let validator = ComponentInstantiationValidator(components: components, urlFileContents: [urlContent], executor: executor, timeout: 3)
         do {
             try validator.process()
         } catch {
@@ -41,9 +41,9 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
     }
 
     func test_withInvalidInstantiations_verifyErrors() {
-        var content = self.content(of: "InvalidInits/InvalidInits1.swift")
+        var urlContent = self.urlContent(of: "InvalidInits/InvalidInits1.swift")
         let components = [astComponent(withName: "MyComponent"), astComponent(withName: "MyComponent2"), astComponent(withName: "My5Component"), astComponent(withName: "MyComp6onent6"), astComponent(withName: "RootComponent")]
-        var validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
+        var validator = ComponentInstantiationValidator(components: components, urlFileContents: [urlContent], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -51,8 +51,8 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
             validate(error: error, withComponentName: "MyComponent")
         }
 
-        content = self.content(of: "InvalidInits/InvalidInits2.swift")
-        validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
+        urlContent = self.urlContent(of: "InvalidInits/InvalidInits2.swift")
+        validator = ComponentInstantiationValidator(components: components, urlFileContents: [urlContent], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -60,8 +60,8 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
             validate(error: error, withComponentName: "MyComponent2")
         }
 
-        content = self.content(of: "InvalidInits/InvalidInits3.swift")
-        validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
+        urlContent = self.urlContent(of: "InvalidInits/InvalidInits3.swift")
+        validator = ComponentInstantiationValidator(components: components, urlFileContents: [urlContent], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -69,8 +69,8 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
             validate(error: error, withComponentName: "My5Component")
         }
 
-        content = self.content(of: "InvalidInits/InvalidInits4.swift")
-        validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
+        urlContent = self.urlContent(of: "InvalidInits/InvalidInits4.swift")
+        validator = ComponentInstantiationValidator(components: components, urlFileContents: [urlContent], executor: executor, timeout: 3)
         do {
             try validator.process()
             XCTFail()
@@ -80,9 +80,9 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
     }
 
     func test_withInvalidInstantiations_notAComponent_verifyNoError() {
-        let content = self.content(of: "InvalidInits/InvalidInits1.swift")
+        let urlContent = self.urlContent(of: "InvalidInits/InvalidInits1.swift")
         let components = [astComponent(withName: "ADifferentComponent")]
-        let validator = ComponentInstantiationValidator(components: components, fileContents: [content], executor: executor, timeout: 3)
+        let validator = ComponentInstantiationValidator(components: components, urlFileContents: [urlContent], executor: executor, timeout: 3)
         do {
             try validator.process()
         } catch {
@@ -90,9 +90,9 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
         }
     }
 
-    private func content(of fileName: String) -> String {
+    private func urlContent(of fileName: String) -> UrlFileContent {
         let fileUrl = fixtureUrl(for: fileName)
-        return try! String(contentsOf: fileUrl)
+        return try! (fileUrl, String(contentsOf: fileUrl))
     }
 
     private func astComponent(withName name: String) -> ASTComponent{

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
@@ -84,7 +84,8 @@ class DependencyGraphParserTests: AbstractParserTests {
         } catch {
             switch error {
             case GeneratorError.withMessage(let message):
-                XCTAssertTrue(message.contains("is instantiated incorrectly. All components must be instantiated by parent components, by passing `self` as the argument to the parent parameter."))
+                XCTAssertTrue(message.contains("is instantiated incorrectly"))
+                XCTAssertTrue(message.contains("All components must be instantiated by parent components, by passing `self` as the argument to the parent parameter."))
             default:
                 XCTFail()
             }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
@@ -85,7 +85,8 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
         } catch {
             switch error {
             case GeneratorError.withMessage(let message):
-                XCTAssertTrue(message.contains("is instantiated incorrectly. All components must be instantiated by parent components, by passing `self` as the argument to the parent parameter."))
+                XCTAssertTrue(message.contains("is instantiated incorrectly"))
+                XCTAssertTrue(message.contains("All components must be instantiated by parent components, by passing `self` as the argument to the parent parameter."))
             default:
                 XCTFail()
             }


### PR DESCRIPTION
Include the URL of the file that contains invalid component instantiations, in the error message.