### PR TITLE
Temporary fix for missing error messages

### DIFF
--- a/Generator/Sources/NeedleFramework/Entry/Generator.swift
+++ b/Generator/Sources/NeedleFramework/Entry/Generator.swift
@@ -211,7 +211,7 @@ public class Generator {
                     sourceKitUtilities.initialize()
                 }
             } catch {
-                throw error
+                fatalError("\(error)")
             }
         }
     }


### PR DESCRIPTION
Instead of throwing the error out of the `Generator` which can cause the executor to deallocate, triggering the concurrency library issue https://github.com/uber/swift-concurrency/issues/29 this change directly `fatalError` so the parsing error is surfaced.