### PR TITLE
Tweak Dagger mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Needle is a dependency injection (DI) system for Swift. Unlike other DI frameworks, such as [Cleanse](https://github.com/square/Cleanse), [Swinject](https://github.com/Swinject/Swinject), Needle encourages **hierarchical DI structure and utilizes code generation to ensure compile-time safety**. This allows us to develop our apps and make code changes with confidence. **If it compiles, it works.** In this aspect, Needle is more similar to [Android Dagger](https://google.github.io/dagger/).
+Needle is a dependency injection (DI) system for Swift. Unlike other DI frameworks, such as [Cleanse](https://github.com/square/Cleanse), [Swinject](https://github.com/Swinject/Swinject), Needle encourages **hierarchical DI structure and utilizes code generation to ensure compile-time safety**. This allows us to develop our apps and make code changes with confidence. **If it compiles, it works.** In this aspect, Needle is more similar to [Dagger for the JVM](https://google.github.io/dagger/).
 
 Needle aims to achieve the following primary goals:
 1. Provide high reliability by ensuring dependency injection code is compile-time safe.


### PR DESCRIPTION
Dagger is a JVM library, not specifically an Android library. "Dagger-android" is one of its artifacts, but needle is actually nothing like that specific artifact :)