### PR TITLE
Update concurrency library and revert previous temporary fix

### DIFF
--- a/Generator/Sources/NeedleFramework/Entry/Generator.swift
+++ b/Generator/Sources/NeedleFramework/Entry/Generator.swift
@@ -211,7 +211,7 @@ public class Generator {
                     sourceKitUtilities.initialize()
                 }
             } catch {
-                fatalError("\(error)")
+                throw error
             }
         }
     }


### PR DESCRIPTION
Concurrency library has addressed the root issue https://github.com/uber/swift-concurrency/issues/29 This reverts back the previous temporary fix https://github.com/uber/needle/pull/250 and relies on the root cause fix in the concurrency library.

Fixes #249