### PR TITLE
Rename Needle podspec to NeedleFoundation

### DIFF
--- a/NeedleFoundation.podspec
+++ b/NeedleFoundation.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = 'Needle'
+  s.name             = 'NeedleFoundation'
   s.version          = '0.9.0'
   s.summary          = 'Compile-time safe Swift dependency injection framework with real code.'
   s.description      = 'Needle is a dependency injection (DI) system for Swift. Unlike other DI frameworks, such as Cleanse, Swinject, Needle encourages hierarchical DI structure and utilizes code generation to ensure compile-time safety. This allows us to develop our apps and make changes with confidence. If it compiles, it works. In this aspect, Needle is more similar to Android Dagger.'


### PR DESCRIPTION
Needle generator expects framework with name `NeedleFoundation` to exist.
Current podspec has name `Needle` therefore code fails to build since there is no such pod with name `NeedleFoundation`.

