### PR TITLE
Explicitly parse root component based on inheritance

### DIFF
--- a/Generator/Sources/NeedleFramework/Models/Component.swift
+++ b/Generator/Sources/NeedleFramework/Models/Component.swift
@@ -21,6 +21,8 @@ import Foundation
 struct Component: Equatable {
     /// The name of the component.
     let name: String
+    /// Indicates if this component is the root of a dependency graph.
+    let isRoot: Bool
     /// A list of properties this component instantiates, thereby provides.
     let properties: [Property]
     /// A list of parent components.
@@ -39,6 +41,8 @@ class ASTComponent {
     let name: String
     /// The name of the component's dependency protocol.
     let dependencyProtocolName: String
+    /// Indicates if this component is the root of a dependency graph.
+    let isRoot: Bool
     /// A list of properties this component instantiates, thereby provides.
     var properties: [Property]
     /// A list of expression call type names.
@@ -53,13 +57,14 @@ class ASTComponent {
         let parentValues = parents.map { (parent: ASTComponent) -> Component in
             parent.valueType
         }
-        return Component(name: name, properties: properties, parents: parentValues, dependency: dependencyProtocol!)
+        return Component(name: name, isRoot: isRoot, properties: properties, parents: parentValues, dependency: dependencyProtocol!)
     }
 
     /// Initializer.
-    init(name: String, dependencyProtocolName: String, properties: [Property], expressionCallTypeNames: [String]) {
+    init(name: String, dependencyProtocolName: String, isRoot: Bool, properties: [Property], expressionCallTypeNames: [String]) {
         self.name = name
         self.dependencyProtocolName = dependencyProtocolName
+        self.isRoot = isRoot
         self.properties = properties
         self.expressionCallTypeNames = expressionCallTypeNames
     }

--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTDeclarationParserTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/Tasks/PluginizedASTDeclarationParserTask.swift
@@ -57,12 +57,14 @@ class PluginizedDeclarationsParserTask: AbstractTask<PluginizedDependencyGraphNo
             if substructure.isPluginizedComponent {
                 let (dependencyProtocolName, pluginExtensionName, nonCoreComponentName) = try substructure.pluginizedGenerics()
                 let properties = try substructure.properties()
-                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
+                // Pluginized components are never root.
+                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, isRoot: false, properties: properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
                 pluginizedComponents.append(PluginizedASTComponent(data: component, pluginExtensionType: pluginExtensionName, nonCoreComponentType: nonCoreComponentName))
             } else if substructure.isNonCoreComponent {
                 let dependencyProtocolName = try substructure.dependencyProtocolName(for: "NonCoreComponent")
                 let properties = try substructure.properties()
-                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, properties: properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
+                // Non-core components are never root.
+                let component = ASTComponent(name: substructure.name, dependencyProtocolName: dependencyProtocolName, isRoot: false, properties: properties, expressionCallTypeNames: substructure.uniqueExpressionCallNames)
                 nonCoreComponents.append(component)
             } else if substructure.isPluginExtension {
                 let properties = try substructure.properties()

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -53,6 +53,14 @@ class SomeNonCoreComponent: NeedleFoundation.NonCoreComponent<    SomeNonCoreDep
     }
 }
 
+class MyRComp: NeedleFoundation.RootComponent {
+    var rootObj: Obj {
+        return shared {
+            Obj()
+        }
+    }
+}
+
 class My2Component: Component<My2Dependency> {
     var book: Book {
         return shared {

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/AncestorCycleValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/AncestorCycleValidatorTests.swift
@@ -20,11 +20,11 @@ import XCTest
 class AncestorCycleValidatorTests: XCTestCase {
 
     func test_process_hasCycle() {
-        let a = ASTComponent(name: "A", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let b = ASTComponent(name: "B", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let c = ASTComponent(name: "C", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let d = ASTComponent(name: "D", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let m = ASTComponent(name: "M", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
+        let a = ASTComponent(name: "A", dependencyProtocolName: "blah", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let b = ASTComponent(name: "B", dependencyProtocolName: "blah", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let c = ASTComponent(name: "C", dependencyProtocolName: "blah", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let d = ASTComponent(name: "D", dependencyProtocolName: "blah", isRoot: true, properties: [], expressionCallTypeNames: [])
+        let m = ASTComponent(name: "M", dependencyProtocolName: "blah", isRoot: true, properties: [], expressionCallTypeNames: [])
         a.parents = [b, m]
         b.parents = [c, d]
         c.parents = [b]
@@ -38,11 +38,11 @@ class AncestorCycleValidatorTests: XCTestCase {
     }
 
     func test_process_noCycle() {
-        let a = ASTComponent(name: "A", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let b = ASTComponent(name: "B", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let c = ASTComponent(name: "C", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let d = ASTComponent(name: "D", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
-        let m = ASTComponent(name: "M", dependencyProtocolName: "blah", properties: [], expressionCallTypeNames: [])
+        let a = ASTComponent(name: "A", dependencyProtocolName: "blah", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let b = ASTComponent(name: "B", dependencyProtocolName: "blah", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let c = ASTComponent(name: "C", dependencyProtocolName: "blah", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let d = ASTComponent(name: "D", dependencyProtocolName: "blah", isRoot: true, properties: [], expressionCallTypeNames: [])
+        let m = ASTComponent(name: "M", dependencyProtocolName: "blah", isRoot: true, properties: [], expressionCallTypeNames: [])
         a.parents = [b, m]
         b.parents = [c, d]
         c.parents = [m]

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentConsolidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentConsolidatorTests.swift
@@ -21,7 +21,7 @@ import XCTest
 class ComponentConsolidatorTests: AbstractParserTests {
 
     func test_process_withMatchingSets_verifyResults() {
-        let components = [ASTComponent(name: "A", dependencyProtocolName: "", properties: [Property(name: "p1", type: "P1")], expressionCallTypeNames: ["E1"])]
+        let components = [ASTComponent(name: "A", dependencyProtocolName: "", isRoot: false, properties: [Property(name: "p1", type: "P1")], expressionCallTypeNames: ["E1"])]
         let componentExtensions = [ASTComponentExtension(name: "A", properties: [Property(name: "p2", type: "P2")], expressionCallTypeNames: ["E2"])]
 
         let processor = ComponentConsolidator(components: components, componentExtensions: componentExtensions)

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentExtensionFilterTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentExtensionFilterTests.swift
@@ -22,7 +22,7 @@ class ComponentExtensionFilterTests: AbstractParserTests {
     func test_execute_hasComponentExtension_verifyFilter() {
         let fileUrl = fixtureUrl(for: "HasComponentExtensions.swift")
         let content = try! String(contentsOf: fileUrl)
-        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "MyScope", dependencyProtocolName: "", properties: [], expressionCallTypeNames: [])])
+        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "MyScope", dependencyProtocolName: "", isRoot: false, properties: [], expressionCallTypeNames: [])])
 
         XCTAssertTrue(filter.filter())
     }
@@ -30,7 +30,7 @@ class ComponentExtensionFilterTests: AbstractParserTests {
     func test_execute_hasExtensionNotForComponent_verifyFilter() {
         let fileUrl = fixtureUrl(for: "HasComponentExtensions.swift")
         let content = try! String(contentsOf: fileUrl)
-        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "NotRightComponent", dependencyProtocolName: "", properties: [], expressionCallTypeNames: [])])
+        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "NotRightComponent", dependencyProtocolName: "", isRoot: false, properties: [], expressionCallTypeNames: [])])
 
         XCTAssertFalse(filter.filter())
     }
@@ -38,7 +38,7 @@ class ComponentExtensionFilterTests: AbstractParserTests {
     func test_execute_noExtensionHasComponent_verifyFilter() {
         let fileUrl = fixtureUrl(for: "ComponentSample.swift")
         let content = try! String(contentsOf: fileUrl)
-        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "MyComponent", dependencyProtocolName: "", properties: [], expressionCallTypeNames: [])])
+        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "MyComponent", dependencyProtocolName: "", isRoot: false, properties: [], expressionCallTypeNames: [])])
 
         XCTAssertFalse(filter.filter())
     }
@@ -46,7 +46,7 @@ class ComponentExtensionFilterTests: AbstractParserTests {
     func test_execute_noExtensionNoComponent_verifyFilter() {
         let fileUrl = fixtureUrl(for: "nocomp.swift")
         let content = try! String(contentsOf: fileUrl)
-        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "MyComponent", dependencyProtocolName: "", properties: [], expressionCallTypeNames: [])])
+        let filter = ComponentExtensionFilter(content: content, components: [ASTComponent(name: "MyComponent", dependencyProtocolName: "", isRoot: false, properties: [], expressionCallTypeNames: [])])
 
         XCTAssertFalse(filter.filter())
     }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentInstantiationValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ComponentInstantiationValidatorTests.swift
@@ -96,7 +96,7 @@ class ComponentInstantiationValidatorTests: AbstractParserTests {
     }
 
     private func astComponent(withName name: String) -> ASTComponent{
-        return ASTComponent(name: name, dependencyProtocolName: "", properties: [], expressionCallTypeNames: [])
+        return ASTComponent(name: name, dependencyProtocolName: "", isRoot: false, properties: [], expressionCallTypeNames: [])
     }
 
     private func validate(error: Error, withComponentName componentName: String) {

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DeclarationsParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DeclarationsParserTaskTests.swift
@@ -46,14 +46,16 @@ class DeclarationsParserTaskTests: AbstractParserTests {
         let task = DeclarationsParserTask(ast: AST(structure: structure, imports: imports))
         let node = try! task.execute()
 
-        XCTAssertEqual(node.components.count, 2)
+        XCTAssertEqual(node.components.count, 3)
 
+        // MyComponent.
         let myComponent = node.components.first { (component: ASTComponent) -> Bool in
             component.name == "MyComponent"
         }!
         XCTAssertEqual(myComponent.expressionCallTypeNames, ["Basket", "Donut", "MyChildComponent", "Stream", "shared"])
         XCTAssertEqual(myComponent.name, "MyComponent")
         XCTAssertEqual(myComponent.dependencyProtocolName, "MyDependency")
+        XCTAssertFalse(myComponent.isRoot)
         XCTAssertEqual(myComponent.properties.count, 4)
         let containsStream = myComponent.properties.contains { (property: Property) -> Bool in
             return property.name == "stream" && property.type == "Stream"
@@ -72,12 +74,14 @@ class DeclarationsParserTaskTests: AbstractParserTests {
         }
         XCTAssertTrue(containsChildComponent)
 
+        // My2Component.
         let my2Component = node.components.first { (component: ASTComponent) -> Bool in
             component.name == "My2Component"
         }!
         XCTAssertEqual(my2Component.expressionCallTypeNames, ["Apple", "Banana", "Book", "Wallet", "shared"])
         XCTAssertEqual(my2Component.name, "My2Component")
         XCTAssertEqual(my2Component.dependencyProtocolName, "My2Dependency")
+        XCTAssertFalse(my2Component.isRoot)
         XCTAssertEqual(my2Component.properties.count, 2)
         let containsBook = my2Component.properties.contains { (property: Property) -> Bool in
             return property.name == "book" && property.type == "Book"
@@ -89,6 +93,7 @@ class DeclarationsParserTaskTests: AbstractParserTests {
         }
         XCTAssertTrue(containsOptionalWallet)
 
+        // MyDependency.
         XCTAssertEqual(node.dependencies.count, 4)
         let myDependency = node.dependencies.first { (dependency: Dependency) -> Bool in
             dependency.name == "MyDependency"
@@ -104,6 +109,7 @@ class DeclarationsParserTaskTests: AbstractParserTests {
         }
         XCTAssertTrue(containsCheese)
 
+        // My2Dependency.
         let my2Dependency = node.dependencies.first { (dependency: Dependency) -> Bool in
             dependency.name == "My2Dependency"
         }!
@@ -119,6 +125,18 @@ class DeclarationsParserTaskTests: AbstractParserTests {
         }
         XCTAssertTrue(containsOptionalMoney)
 
+        // MyRComp.
+        let myRComp = node.components.first { (component: ASTComponent) -> Bool in
+            component.name == "MyRComp"
+        }!
+        XCTAssertEqual(myRComp.expressionCallTypeNames, ["Obj", "shared"])
+        XCTAssertEqual(myRComp.name, "MyRComp")
+        XCTAssertEqual(myRComp.dependencyProtocolName, "EmptyDependency")
+        XCTAssertTrue(myRComp.isRoot)
+        XCTAssertEqual(myRComp.properties.count, 1)
+        XCTAssertEqual(myRComp.properties, [Property(name: "rootObj", type: "Obj")])
+
+        // Imports.
         XCTAssertEqual(node.imports, ["import UIKit", "import RIBs", "import Foundation"])
     }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
@@ -67,7 +67,7 @@ class DependencyGraphParserTests: AbstractParserTests {
             let childComponent = components.filter { $0.name == "MyChildComponent" }.first!
             let parentComponent = components.filter { $0.name == "MyComponent" }.first!
             XCTAssertTrue(childComponent.parents.first! == parentComponent)
-            XCTAssertEqual(components.count, 9)
+            XCTAssertEqual(components.count, 10)
             XCTAssertEqual(imports, ["import Foundation", "import RIBs", "import RxSwift", "import UIKit", "import Utility"])
         } catch {
             XCTFail("\(error)")

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyLinkerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyLinkerTests.swift
@@ -21,7 +21,7 @@ import XCTest
 class DependencyLinkerTests: AbstractParserTests {
 
     func test_process_withComponents_verifyLinkages() {
-        let component = ASTComponent(name: "SomeComp", dependencyProtocolName: "ItsDependency", properties: [], expressionCallTypeNames: [])
+        let component = ASTComponent(name: "SomeComp", dependencyProtocolName: "ItsDependency", isRoot: false, properties: [], expressionCallTypeNames: [])
         let dependency = Dependency(name: "ItsDependency", properties: [])
 
         let linker = DependencyLinker(components: [component], dependencies: [dependency])
@@ -32,7 +32,7 @@ class DependencyLinkerTests: AbstractParserTests {
     }
 
     func test_process_withComponentsNoDependency_verifyError() {
-        let component = ASTComponent(name: "SomeComp", dependencyProtocolName: "ItsDependency", properties: [], expressionCallTypeNames: [])
+        let component = ASTComponent(name: "SomeComp", dependencyProtocolName: "ItsDependency", isRoot: false, properties: [], expressionCallTypeNames: [])
         let dependency = Dependency(name: "WrongDep", properties: [])
 
         let linker = DependencyLinker(components: [component], dependencies: [dependency])

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DuplicateValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DuplicateValidatorTests.swift
@@ -21,9 +21,9 @@ import XCTest
 class DuplicateValidatorTests: XCTestCase {
     
     func test_validateComponent_noDuplicate_verifyResult() {
-        let comp1 = ASTComponent(name: "ha1", dependencyProtocolName: "dep1", properties: [], expressionCallTypeNames: [])
-        let comp2 = ASTComponent(name: "ha2", dependencyProtocolName: "dep1", properties: [], expressionCallTypeNames: [])
-        let comp3 = ASTComponent(name: "ha3", dependencyProtocolName: "dep1", properties: [], expressionCallTypeNames: [])
+        let comp1 = ASTComponent(name: "ha1", dependencyProtocolName: "dep1", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let comp2 = ASTComponent(name: "ha2", dependencyProtocolName: "dep1", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let comp3 = ASTComponent(name: "ha3", dependencyProtocolName: "dep1", isRoot: false, properties: [], expressionCallTypeNames: [])
 
         let validator = DuplicateValidator(components: [comp1, comp2, comp3], dependencies: [])
 
@@ -31,9 +31,9 @@ class DuplicateValidatorTests: XCTestCase {
     }
 
     func test_validateComponent_withDuplicates_verifyResult() {
-        let comp1 = ASTComponent(name: "ha1", dependencyProtocolName: "dep1", properties: [], expressionCallTypeNames: [])
-        let comp2 = ASTComponent(name: "ha1", dependencyProtocolName: "dep1", properties: [], expressionCallTypeNames: [])
-        let comp3 = ASTComponent(name: "ha3", dependencyProtocolName: "dep1", properties: [], expressionCallTypeNames: [])
+        let comp1 = ASTComponent(name: "ha1", dependencyProtocolName: "dep1", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let comp2 = ASTComponent(name: "ha1", dependencyProtocolName: "dep1", isRoot: false, properties: [], expressionCallTypeNames: [])
+        let comp3 = ASTComponent(name: "ha3", dependencyProtocolName: "dep1", isRoot: false, properties: [], expressionCallTypeNames: [])
 
         let validator = DuplicateValidator(components: [comp1, comp2, comp3], dependencies: [])
 

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ParentLinkerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ParentLinkerTests.swift
@@ -20,8 +20,8 @@ import XCTest
 class ParentLinkerTests: AbstractParserTests {
 
     func test_process_withComponents_verifyLinkages() {
-        let parentComponent = ASTComponent(name: "ParentComp", dependencyProtocolName: "Doesn't matter", properties: [], expressionCallTypeNames: ["ChildComp", "someOtherStuff"])
-        let childComp = ASTComponent(name: "ChildComp", dependencyProtocolName: "Still doesn't matter", properties: [], expressionCallTypeNames: [])
+        let parentComponent = ASTComponent(name: "ParentComp", dependencyProtocolName: "Doesn't matter", isRoot: true, properties: [], expressionCallTypeNames: ["ChildComp", "someOtherStuff"])
+        let childComp = ASTComponent(name: "ChildComp", dependencyProtocolName: "Still doesn't matter", isRoot: false, properties: [], expressionCallTypeNames: [])
 
         let linker = ParentLinker(components: [parentComponent, childComp])
         try! linker.process()

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/NonCoreComponentLinkerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/NonCoreComponentLinkerTests.swift
@@ -21,9 +21,9 @@ import XCTest
 class NonCoreComponentLinkerTests: AbstractParserTests {
 
     func test_process_withComponents_verifyLinkages() {
-        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", properties: [], expressionCallTypeNames: [])
+        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", isRoot: true, properties: [], expressionCallTypeNames: [])
         let pluginizedComp = PluginizedASTComponent(data: data, pluginExtensionType: "Doesn't matter", nonCoreComponentType: "SomeComp")
-        let nonCoreComponent = ASTComponent(name: "SomeComp", dependencyProtocolName: "ItsDependency", properties: [], expressionCallTypeNames: [])
+        let nonCoreComponent = ASTComponent(name: "SomeComp", dependencyProtocolName: "ItsDependency", isRoot: false, properties: [], expressionCallTypeNames: [])
 
         let linker = NonCoreComponentLinker(pluginizedComponents: [pluginizedComp], nonCoreComponents: [nonCoreComponent])
 
@@ -33,9 +33,9 @@ class NonCoreComponentLinkerTests: AbstractParserTests {
     }
 
     func test_process_withComponentsNoNonCoreComp_verifyError() {
-        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", properties: [], expressionCallTypeNames: [])
+        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", isRoot: false, properties: [], expressionCallTypeNames: [])
         let pluginizedComp = PluginizedASTComponent(data: data, pluginExtensionType: "Doesn't matter", nonCoreComponentType: "SomeComp")
-        let nonCoreComponent = ASTComponent(name: "WrongNonCoreComp", dependencyProtocolName: "ItsDependency", properties: [], expressionCallTypeNames: [])
+        let nonCoreComponent = ASTComponent(name: "WrongNonCoreComp", dependencyProtocolName: "ItsDependency", isRoot: true, properties: [], expressionCallTypeNames: [])
 
         let linker = NonCoreComponentLinker(pluginizedComponents: [pluginizedComp], nonCoreComponents: [nonCoreComponent])
 

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionCycleValidatorTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionCycleValidatorTests.swift
@@ -24,10 +24,10 @@ class PluginExtensionCycleValidatorTests: AbstractPluginizedParserTests {
         let pluginExtension = PluginExtension(name: "PE", properties: [Property(name: "a", type: "A")])
 
         let nonCoreDependency = Dependency(name: "NonCoreDep", properties: [Property(name: "b", type: "B")])
-        let nonCoreComponent = ASTComponent(name: "NonCoreComp", dependencyProtocolName: "NonCoreDep", properties: [Property(name: "c", type: "D")], expressionCallTypeNames: [])
+        let nonCoreComponent = ASTComponent(name: "NonCoreComp", dependencyProtocolName: "NonCoreDep", isRoot: false, properties: [Property(name: "c", type: "D")], expressionCallTypeNames: [])
         nonCoreComponent.dependencyProtocol = nonCoreDependency
 
-        let coreComponent = ASTComponent(name: "CoreComp", dependencyProtocolName: "blah", properties: [Property(name: "e", type: "E")], expressionCallTypeNames: [])
+        let coreComponent = ASTComponent(name: "CoreComp", dependencyProtocolName: "blah", isRoot: true, properties: [Property(name: "e", type: "E")], expressionCallTypeNames: [])
         let pluginizedComponent = PluginizedASTComponent(data: coreComponent, pluginExtensionType: "PE", nonCoreComponentType: "NonCoreComp")
         pluginizedComponent.pluginExtension = pluginExtension
         pluginizedComponent.nonCoreComponent = nonCoreComponent
@@ -45,10 +45,10 @@ class PluginExtensionCycleValidatorTests: AbstractPluginizedParserTests {
         let pluginExtension = PluginExtension(name: "PE", properties: [Property(name: "a", type: "A")])
 
         let nonCoreDependency = Dependency(name: "NonCoreDep", properties: [Property(name: "a", type: "A")])
-        let nonCoreComponent = ASTComponent(name: "NonCoreComp", dependencyProtocolName: "NonCoreDep", properties: [Property(name: "c", type: "D")], expressionCallTypeNames: [])
+        let nonCoreComponent = ASTComponent(name: "NonCoreComp", dependencyProtocolName: "NonCoreDep", isRoot: false, properties: [Property(name: "c", type: "D")], expressionCallTypeNames: [])
         nonCoreComponent.dependencyProtocol = nonCoreDependency
 
-        let coreComponent = ASTComponent(name: "CoreComp", dependencyProtocolName: "blah", properties: [Property(name: "a", type: "A")], expressionCallTypeNames: [])
+        let coreComponent = ASTComponent(name: "CoreComp", dependencyProtocolName: "blah", isRoot: true, properties: [Property(name: "a", type: "A")], expressionCallTypeNames: [])
         let pluginizedComponent = PluginizedASTComponent(data: coreComponent, pluginExtensionType: "PE", nonCoreComponentType: "NonCoreComp")
         pluginizedComponent.pluginExtension = pluginExtension
         pluginizedComponent.nonCoreComponent = nonCoreComponent

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionLinkerTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginExtensionLinkerTests.swift
@@ -21,7 +21,7 @@ import XCTest
 class PluginExtensionLinkerTests: AbstractParserTests {
 
     func test_process_withComponents_verifyLinkages() {
-        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", properties: [], expressionCallTypeNames: [])
+        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", isRoot: false, properties: [], expressionCallTypeNames: [])
         let pluginizedComp = PluginizedASTComponent(data: data, pluginExtensionType: "MyExtension", nonCoreComponentType: "Doesn't matter")
         let pluginExtension = PluginExtension(name: "MyExtension", properties: [])
 
@@ -33,7 +33,7 @@ class PluginExtensionLinkerTests: AbstractParserTests {
     }
 
     func test_process_withComponentsNoPluginExtension_verifyError() {
-        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", properties: [], expressionCallTypeNames: [])
+        let data = ASTComponent(name: "SomePluginizedComp", dependencyProtocolName: "Doesn't matter", isRoot: false, properties: [], expressionCallTypeNames: [])
         let pluginizedComp = PluginizedASTComponent(data: data, pluginExtensionType: "StuffExtension", nonCoreComponentType: "SomeComp")
 
         let linker = PluginExtensionLinker(pluginizedComponents: [pluginizedComp], pluginExtensions: [])

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDeclarationsParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDeclarationsParserTaskTests.swift
@@ -30,7 +30,7 @@ class PluginizedDeclarationsParserTaskTests: AbstractParserTests {
         let node = try! task.execute()
 
         // Regular components.
-        XCTAssertEqual(node.components.count, 2)
+        XCTAssertEqual(node.components.count, 3)
         let myComponent = node.components.first { (component: ASTComponent) -> Bool in
             component.name == "MyComponent"
         }!
@@ -70,6 +70,16 @@ class PluginizedDeclarationsParserTaskTests: AbstractParserTests {
             return property.name == "maybeWallet" && property.type == "Wallet?"
         }
         XCTAssertTrue(containsOptionalWallet)
+
+        let myRComp = node.components.first { (component: ASTComponent) -> Bool in
+            component.name == "MyRComp"
+            }!
+        XCTAssertEqual(myRComp.expressionCallTypeNames, ["Obj", "shared"])
+        XCTAssertEqual(myRComp.name, "MyRComp")
+        XCTAssertEqual(myRComp.dependencyProtocolName, "EmptyDependency")
+        XCTAssertTrue(myRComp.isRoot)
+        XCTAssertEqual(myRComp.properties.count, 1)
+        XCTAssertEqual(myRComp.properties, [Property(name: "rootObj", type: "Obj")])
 
         // Non-core components.
         XCTAssertEqual(node.nonCoreComponents.count, 1)

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
@@ -67,7 +67,7 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
             let childComponent = components.filter { $0.name == "MyChildComponent" }.first!
             let parentComponent = components.filter { $0.name == "MyComponent" }.first!
             XCTAssertTrue(childComponent.parents.first! == parentComponent)
-            XCTAssertEqual(components.count, 13)
+            XCTAssertEqual(components.count, 14)
             XCTAssertEqual(pluginizedComponents.count, 3)
             XCTAssertEqual(imports, ["import Foundation", "import NeedleFoundation", "import RIBs", "import RxSwift", "import ScoreSheet", "import UIKit", "import Utility"])
         } catch {


### PR DESCRIPTION
Parse if a component is root based on if it inherits from the `RootComponent` type.