### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: objective-c
 osx_image: xcode10.1
+before_script:
+- "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 matrix:
     include:
         - name: "NeedleFoundationTests"
@@ -23,3 +25,5 @@ matrix:
         - name: "NeedleSamplePluginizedTicTacToeCoreTests"
           install: cd Sample/Pluginized && carthage update --platform ios
           script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeCoreTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+script:
+    - fossa


### PR DESCRIPTION
I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment.