### PR TITLE
Ignore orphan scopes

### DIFF
--- a/API.md
+++ b/API.md
@@ -121,27 +121,17 @@ Once this tree structure has been declared in code, the needle command-line tool
 
 # Bootstrap Root
 
-Since the root of a DI tree does not have a parent component, we bootstrap the root scope using the special `BootstrapComponent` class
+Since the root of a DI tree does not have a parent component, we bootstrap the root scope using the special `NeedleFoundation.RootComponent` class
 ```swift
-let rootComponent = RootComponent(parent: BootstrapComponent())
+let rootComponent = RootComponent()
 
-class RootComponent: Component<EmptyDependency> {
+class RootComponent: NeedleFoundation.RootComponent {
     /// Root component code...
 }
 ```
-Notice also the `RootComponent` uses the special `EmptyDependency` protocol to signal that it has no dependencies from its ancestors. In this case, root does not have any ancestors to speak of anyways.
+Notice the `RootComponent` does not need to specify any dependency protocol by inheriting from `NeedleFoundation.RootComponent`. Root of a DI graph has no parent to acquire dependencies from anyways.
 
-The `EmptyDependency` protocol can also be used for any other scopes that do not pull down dependencies from their ancestor DI branches.
-
-For better encapsulation, we can also define a custom initializer to a Root scope
-```swift
-class RootComponent: Component<EmptyDependency> {
-    init() {
-        super.init(parent: BootstrapComponent())
-    }
-}
-```
-This allows component subclass to encapsulate the special `BootstrapComponent` usage. In application code, we can simply invoke `RootComponent()` to instantiate the root scope.
+Since we know `root` does not have any parents, in application code, we can simply invoke `RootComponent()` to instantiate the root scope.
 
 # Flexibility
 

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderDeclarerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderDeclarerTask.swift
@@ -55,7 +55,7 @@ class DependencyProviderDeclarerTask: AbstractTask<[DependencyProvider]> {
                     return DependencyProvider(path: path, dependency: component.dependency)
                 } else {
                     let pathString = path.map { $0.name }.joined(separator: "->")
-                    warning("\(pathString) is an orphan chain, therefore all scopes within the chain are ignored from parsing.")
+                    info("\(pathString) is an orphan chain, therefore all scopes within the chain are ignored from parsing.")
                     return nil
                 }
             }

--- a/Sample/MVC/TicTacToe/Sources/AppDelegate.swift
+++ b/Sample/MVC/TicTacToe/Sources/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
 
-        let rootComponent = RootComponent(parent: BootstrapComponent())
+        let rootComponent = RootComponent()
         window.rootViewController = rootComponent.rootViewController
 
         window.makeKeyAndVisible()

--- a/Sample/MVC/TicTacToe/Sources/Root/RootComponent.swift
+++ b/Sample/MVC/TicTacToe/Sources/Root/RootComponent.swift
@@ -17,7 +17,7 @@
 import NeedleFoundation
 import UIKit
 
-class RootComponent: Component<EmptyDependency> {
+class RootComponent: NeedleFoundation.RootComponent {
 
     var playersStream: PlayersStream {
         return mutablePlayersStream

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/AppDelegate.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
 
-        let rootComponent = RootComponent(parent: BootstrapComponent())
+        let rootComponent = RootComponent()
         window.rootViewController = rootComponent.rootViewController
 
         window.makeKeyAndVisible()

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/Root/RootComponent.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/Root/RootComponent.swift
@@ -17,7 +17,7 @@
 import NeedleFoundation
 import UIKit
 
-class RootComponent: Component<EmptyDependency> {
+class RootComponent: NeedleFoundation.RootComponent {
 
     var playersStream: PlayersStream {
         return mutablePlayersStream


### PR DESCRIPTION
Orphan scopes are the scopes that do not ultimately end at a subclass of `RootComponent`. This means they are detached and therefore cannot be provided for. This change ignores parsing these orphans.

Also updated samples and documentation to reflect this new root API change.

Fixes #272