### PR TITLE
[DO_NOT_MERGE] Added unit test support inside NeedleFoundation code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
     include:
         - name: "NeedleFoundationTests"
           script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+        - name: "NeedleFoundationTestTests"
+          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTestTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
         - name: "NeedleGeneratorTests"
           script: cd Generator && swift test -Xswiftc -DDEBUG
         - name: "NeedleGeneratorBinary"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,15 @@ matrix:
           script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=12.1,name=iPhone X'
         - name: "NeedleSampleMVCTests"
           install: cd Sample/MVC && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeTests -destination 'platform=iOS Simulator,OS=12.1,name=iPhone X'
         - name: "NeedleSamplePluginizedApp"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild build -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild build -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=12.1,name=iPhone X'
         - name: "NeedleSamplePluginizedScoreSheetTests"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme ScoreSheetTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme ScoreSheetTests -destination 'platform=iOS Simulator,OS=12.1,name=iPhone X'
         - name: "NeedleSamplePluginizedTicTacToeCoreTests"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeCoreTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeCoreTests -destination 'platform=iOS Simulator,OS=12.1,name=iPhone X'
 script:
     - fossa

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,18 @@ matrix:
           script: cd Generator && swift build -c release -Xswiftc -static-stdlib
         - name: "NeedleSampleMVCApp"
           install: cd Sample/MVC && carthage update --platform ios
-          script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe
+          script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
         - name: "NeedleSampleMVCTests"
           install: cd Sample/MVC && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeTests
+          script: xcodebuild test -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
         - name: "NeedleSamplePluginizedApp"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild build -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe
+          script: xcodebuild build -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
         - name: "NeedleSamplePluginizedScoreSheetTests"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme ScoreSheetTests
+          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme ScoreSheetTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
         - name: "NeedleSamplePluginizedTicTacToeCoreTests"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeCoreTests
+          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeCoreTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
 script:
     - fossa

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,27 @@ before_script:
 matrix:
     include:
         - name: "NeedleFoundationTests"
-          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTests
         - name: "NeedleFoundationTestTests"
-          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTestTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTestTests
         - name: "NeedleGeneratorTests"
           script: cd Generator && swift test -Xswiftc -DDEBUG
         - name: "NeedleGeneratorBinary"
           script: cd Generator && swift build -c release -Xswiftc -static-stdlib
         - name: "NeedleSampleMVCApp"
           install: cd Sample/MVC && carthage update --platform ios
-          script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe
         - name: "NeedleSampleMVCTests"
           install: cd Sample/MVC && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeTests
         - name: "NeedleSamplePluginizedApp"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild build -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild build -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe
         - name: "NeedleSamplePluginizedScoreSheetTests"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme ScoreSheetTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme ScoreSheetTests
         - name: "NeedleSamplePluginizedTicTacToeCoreTests"
           install: cd Sample/Pluginized && carthage update --platform ios
-          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeCoreTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild test -project ../../Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeCoreTests
 script:
     - fossa

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
           script: cd Generator && swift build -c release -Xswiftc -static-stdlib
         - name: "NeedleSampleMVCApp"
           install: cd Sample/MVC && carthage update --platform ios
-          script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'
+          script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=12.1,name=iPhone X'
         - name: "NeedleSampleMVCTests"
           install: cd Sample/MVC && carthage update --platform ios
           script: xcodebuild test -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToeTests -destination 'platform=iOS Simulator,OS=11.4,name=iPhone X'

--- a/NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist
+++ b/NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist
+++ b/NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/NeedleFoundation.xcodeproj/project.pbxproj
+++ b/NeedleFoundation.xcodeproj/project.pbxproj
@@ -1,548 +1,947 @@
 // !$*UTF8*$!
 {
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXAggregateTarget section */
-		"NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" /* NeedleFoundationPackageTests */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_53 /* Build configuration list for PBXAggregateTarget "NeedleFoundationPackageTests" */;
-			buildPhases = (
-			);
-			dependencies = (
-				OBJ_56 /* PBXTargetDependency */,
-			);
-			name = NeedleFoundationPackageTests;
-			productName = NeedleFoundationPackageTests;
-		};
-/* End PBXAggregateTarget section */
-
-/* Begin PBXBuildFile section */
-		OBJ_38 /* Bootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Bootstrap.swift */; };
-		OBJ_39 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Component.swift */; };
-		OBJ_40 /* DependencyProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* DependencyProviderRegistry.swift */; };
-		OBJ_41 /* PluginExtensionProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* PluginExtensionProviderRegistry.swift */; };
-		OBJ_42 /* NonCoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* NonCoreComponent.swift */; };
-		OBJ_43 /* PluginizedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* PluginizedComponent.swift */; };
-		OBJ_44 /* PluginizedScopeLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* PluginizedScopeLifecycle.swift */; };
-		OBJ_51 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_62 /* ComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* ComponentTests.swift */; };
-		OBJ_63 /* DependencyProviderRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* DependencyProviderRegistryTests.swift */; };
-		OBJ_64 /* PluginizedComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* PluginizedComponentTests.swift */; };
-		OBJ_66 /* NeedleFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		4185D7972279029E00BC3A49 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "NeedleFoundation::NeedleFoundation";
-			remoteInfo = NeedleFoundation;
-		};
-		4185D7982279029F00BC3A49 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTests";
-			remoteInfo = NeedleFoundationTests;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		"NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = NeedleFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = NeedleFoundationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		OBJ_11 /* Bootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bootstrap.swift; sourceTree = "<group>"; };
-		OBJ_12 /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
-		OBJ_14 /* DependencyProviderRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyProviderRegistry.swift; sourceTree = "<group>"; };
-		OBJ_17 /* PluginExtensionProviderRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginExtensionProviderRegistry.swift; sourceTree = "<group>"; };
-		OBJ_18 /* NonCoreComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonCoreComponent.swift; sourceTree = "<group>"; };
-		OBJ_19 /* PluginizedComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginizedComponent.swift; sourceTree = "<group>"; };
-		OBJ_20 /* PluginizedScopeLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginizedScopeLifecycle.swift; sourceTree = "<group>"; };
-		OBJ_23 /* ComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentTests.swift; sourceTree = "<group>"; };
-		OBJ_24 /* DependencyProviderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyProviderRegistryTests.swift; sourceTree = "<group>"; };
-		OBJ_26 /* PluginizedComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginizedComponentTests.swift; sourceTree = "<group>"; };
-		OBJ_27 /* Images */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Images; sourceTree = SOURCE_ROOT; };
-		OBJ_28 /* Generator */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Generator; sourceTree = SOURCE_ROOT; };
-		OBJ_29 /* Sample */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Sample; sourceTree = SOURCE_ROOT; };
-		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_8 /* foundation.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = foundation.xcconfig; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		OBJ_45 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_65 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_66 /* NeedleFoundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		OBJ_10 /* NeedleFoundation */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_11 /* Bootstrap.swift */,
-				OBJ_12 /* Component.swift */,
-				OBJ_13 /* Internal */,
-				OBJ_15 /* Pluginized */,
-			);
-			name = NeedleFoundation;
-			path = Sources/NeedleFoundation;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_13 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_14 /* DependencyProviderRegistry.swift */,
-			);
-			path = Internal;
-			sourceTree = "<group>";
-		};
-		OBJ_15 /* Pluginized */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_16 /* Internal */,
-				OBJ_18 /* NonCoreComponent.swift */,
-				OBJ_19 /* PluginizedComponent.swift */,
-				OBJ_20 /* PluginizedScopeLifecycle.swift */,
-			);
-			path = Pluginized;
-			sourceTree = "<group>";
-		};
-		OBJ_16 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_17 /* PluginExtensionProviderRegistry.swift */,
-			);
-			path = Internal;
-			sourceTree = "<group>";
-		};
-		OBJ_21 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_22 /* NeedleFoundationTests */,
-			);
-			name = Tests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_22 /* NeedleFoundationTests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_23 /* ComponentTests.swift */,
-				OBJ_24 /* DependencyProviderRegistryTests.swift */,
-				OBJ_25 /* Pluginized */,
-			);
-			name = NeedleFoundationTests;
-			path = Tests/NeedleFoundationTests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_25 /* Pluginized */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_26 /* PluginizedComponentTests.swift */,
-			);
-			path = Pluginized;
-			sourceTree = "<group>";
-		};
-		OBJ_30 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				"NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */,
-				"NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */,
-			);
-			name = Products;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		OBJ_5 = {
-			isa = PBXGroup;
-			children = (
-				OBJ_6 /* Package.swift */,
-				OBJ_7 /* Configs */,
-				OBJ_9 /* Sources */,
-				OBJ_21 /* Tests */,
-				OBJ_27 /* Images */,
-				OBJ_28 /* Generator */,
-				OBJ_29 /* Sample */,
-				OBJ_30 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		OBJ_7 /* Configs */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_8 /* foundation.xcconfig */,
-			);
-			name = Configs;
-			sourceTree = "<group>";
-		};
-		OBJ_9 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_10 /* NeedleFoundation */,
-			);
-			name = Sources;
-			sourceTree = SOURCE_ROOT;
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		"NeedleFoundation::NeedleFoundation" /* NeedleFoundation */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_34 /* Build configuration list for PBXNativeTarget "NeedleFoundation" */;
-			buildPhases = (
-				OBJ_37 /* Sources */,
-				OBJ_45 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = NeedleFoundation;
-			productName = NeedleFoundation;
-			productReference = "NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_58 /* Build configuration list for PBXNativeTarget "NeedleFoundationTests" */;
-			buildPhases = (
-				OBJ_61 /* Sources */,
-				OBJ_65 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_67 /* PBXTargetDependency */,
-			);
-			name = NeedleFoundationTests;
-			productName = NeedleFoundationTests;
-			productReference = "NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		"NeedleFoundation::SwiftPMPackageDescription" /* NeedleFoundationPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_47 /* Build configuration list for PBXNativeTarget "NeedleFoundationPackageDescription" */;
-			buildPhases = (
-				OBJ_50 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = NeedleFoundationPackageDescription;
-			productName = NeedleFoundationPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		OBJ_1 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastUpgradeCheck = 9999;
-			};
-			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "NeedleFoundation" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				English,
-				en,
-			);
-			mainGroup = OBJ_5;
-			productRefGroup = OBJ_30 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				"NeedleFoundation::NeedleFoundation" /* NeedleFoundation */,
-				"NeedleFoundation::SwiftPMPackageDescription" /* NeedleFoundationPackageDescription */,
-				"NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" /* NeedleFoundationPackageTests */,
-				"NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXSourcesBuildPhase section */
-		OBJ_37 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_38 /* Bootstrap.swift in Sources */,
-				OBJ_39 /* Component.swift in Sources */,
-				OBJ_40 /* DependencyProviderRegistry.swift in Sources */,
-				OBJ_41 /* PluginExtensionProviderRegistry.swift in Sources */,
-				OBJ_42 /* NonCoreComponent.swift in Sources */,
-				OBJ_43 /* PluginizedComponent.swift in Sources */,
-				OBJ_44 /* PluginizedScopeLifecycle.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_50 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_51 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_61 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_62 /* ComponentTests.swift in Sources */,
-				OBJ_63 /* DependencyProviderRegistryTests.swift in Sources */,
-				OBJ_64 /* PluginizedComponentTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		OBJ_56 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */;
-			targetProxy = 4185D7982279029F00BC3A49 /* PBXContainerItemProxy */;
-		};
-		OBJ_67 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "NeedleFoundation::NeedleFoundation" /* NeedleFoundation */;
-			targetProxy = 4185D7972279029E00BC3A49 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		OBJ_3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_NS_ASSERTIONS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-DXcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE DEBUG";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		OBJ_35 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* foundation.xcconfig */;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = NeedleFoundation;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = NeedleFoundation;
-			};
-			name = Debug;
-		};
-		OBJ_36 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* foundation.xcconfig */;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = NeedleFoundation;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = NeedleFoundation;
-			};
-			name = Release;
-		};
-		OBJ_4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_OPTIMIZATION_LEVEL = s;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_SWIFT_FLAGS = "-DXcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		OBJ_48 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Debug;
-		};
-		OBJ_49 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
-		OBJ_54 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		OBJ_55 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		OBJ_59 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* foundation.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = NeedleFoundationTests;
-			};
-			name = Debug;
-		};
-		OBJ_60 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = OBJ_8 /* foundation.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.0;
-				TARGET_NAME = NeedleFoundationTests;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		OBJ_2 /* Build configuration list for PBXProject "NeedleFoundation" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_3 /* Debug */,
-				OBJ_4 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_34 /* Build configuration list for PBXNativeTarget "NeedleFoundation" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_35 /* Debug */,
-				OBJ_36 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_47 /* Build configuration list for PBXNativeTarget "NeedleFoundationPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_48 /* Debug */,
-				OBJ_49 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_53 /* Build configuration list for PBXAggregateTarget "NeedleFoundationPackageTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_54 /* Debug */,
-				OBJ_55 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_58 /* Build configuration list for PBXNativeTarget "NeedleFoundationTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_59 /* Debug */,
-				OBJ_60 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = OBJ_1 /* Project object */;
+   archiveVersion = "1";
+   objectVersion = "46";
+   objects = {
+      "NeedleFoundation::NeedleFoundation" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_38";
+         buildPhases = (
+            "OBJ_41",
+            "OBJ_49"
+         );
+         dependencies = (
+         );
+         name = "NeedleFoundation";
+         productName = "NeedleFoundation";
+         productReference = "NeedleFoundation::NeedleFoundation::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "NeedleFoundation::NeedleFoundation::Product" = {
+         isa = "PBXFileReference";
+         path = "NeedleFoundation.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" = {
+         isa = "PBXAggregateTarget";
+         buildConfigurationList = "OBJ_57";
+         buildPhases = (
+         );
+         dependencies = (
+            "OBJ_60",
+            "OBJ_62"
+         );
+         name = "NeedleFoundationPackageTests";
+         productName = "NeedleFoundationPackageTests";
+      };
+      "NeedleFoundation::NeedleFoundationTest" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_65";
+         buildPhases = (
+            "OBJ_68",
+            "OBJ_70"
+         );
+         dependencies = (
+         );
+         name = "NeedleFoundationTest";
+         productName = "NeedleFoundationTest";
+         productReference = "NeedleFoundation::NeedleFoundationTest::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "NeedleFoundation::NeedleFoundationTest::Product" = {
+         isa = "PBXFileReference";
+         path = "NeedleFoundationTest.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "NeedleFoundation::NeedleFoundationTestTests" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_71";
+         buildPhases = (
+            "OBJ_74",
+            "OBJ_76"
+         );
+         dependencies = (
+            "OBJ_78"
+         );
+         name = "NeedleFoundationTestTests";
+         productName = "NeedleFoundationTestTests";
+         productReference = "NeedleFoundation::NeedleFoundationTestTests::Product";
+         productType = "com.apple.product-type.bundle.unit-test";
+      };
+      "NeedleFoundation::NeedleFoundationTestTests::Product" = {
+         isa = "PBXFileReference";
+         path = "NeedleFoundationTestTests.xctest";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "NeedleFoundation::NeedleFoundationTests" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_79";
+         buildPhases = (
+            "OBJ_82",
+            "OBJ_86"
+         );
+         dependencies = (
+            "OBJ_88"
+         );
+         name = "NeedleFoundationTests";
+         productName = "NeedleFoundationTests";
+         productReference = "NeedleFoundation::NeedleFoundationTests::Product";
+         productType = "com.apple.product-type.bundle.unit-test";
+      };
+      "NeedleFoundation::NeedleFoundationTests::Product" = {
+         isa = "PBXFileReference";
+         path = "NeedleFoundationTests.xctest";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "NeedleFoundation::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_51";
+         buildPhases = (
+            "OBJ_54"
+         );
+         dependencies = (
+         );
+         name = "NeedleFoundationPackageDescription";
+         productName = "NeedleFoundationPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "OBJ_1" = {
+         isa = "PBXProject";
+         attributes = {
+            LastUpgradeCheck = "9999";
+         };
+         buildConfigurationList = "OBJ_2";
+         compatibilityVersion = "Xcode 3.2";
+         developmentRegion = "English";
+         hasScannedForEncodings = "0";
+         knownRegions = (
+            "en"
+         );
+         mainGroup = "OBJ_5";
+         productRefGroup = "OBJ_32";
+         projectDirPath = ".";
+         targets = (
+            "NeedleFoundation::NeedleFoundation",
+            "NeedleFoundation::SwiftPMPackageDescription",
+            "NeedleFoundation::NeedleFoundationPackageTests::ProductTarget",
+            "NeedleFoundation::NeedleFoundationTest",
+            "NeedleFoundation::NeedleFoundationTestTests",
+            "NeedleFoundation::NeedleFoundationTests"
+         );
+      };
+      "OBJ_10" = {
+         isa = "PBXFileReference";
+         path = "Component.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_11" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_12"
+         );
+         name = "Internal";
+         path = "Internal";
+         sourceTree = "<group>";
+      };
+      "OBJ_12" = {
+         isa = "PBXFileReference";
+         path = "DependencyProviderRegistry.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_13" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_14",
+            "OBJ_16",
+            "OBJ_17",
+            "OBJ_18"
+         );
+         name = "Pluginized";
+         path = "Pluginized";
+         sourceTree = "<group>";
+      };
+      "OBJ_14" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_15"
+         );
+         name = "Internal";
+         path = "Internal";
+         sourceTree = "<group>";
+      };
+      "OBJ_15" = {
+         isa = "PBXFileReference";
+         path = "PluginExtensionProviderRegistry.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_16" = {
+         isa = "PBXFileReference";
+         path = "NonCoreComponent.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_17" = {
+         isa = "PBXFileReference";
+         path = "PluginizedComponent.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_18" = {
+         isa = "PBXFileReference";
+         path = "PluginizedScopeLifecycle.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_19" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_20"
+         );
+         name = "NeedleFoundationTest";
+         path = "Sources/NeedleFoundationTest";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_3",
+            "OBJ_4"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_20" = {
+         isa = "PBXFileReference";
+         path = "MockComponentPathBuilder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_21" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_22",
+            "OBJ_27"
+         );
+         name = "Tests";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_22" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_23",
+            "OBJ_24",
+            "OBJ_25"
+         );
+         name = "NeedleFoundationTests";
+         path = "Tests/NeedleFoundationTests";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_23" = {
+         isa = "PBXFileReference";
+         path = "ComponentTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_24" = {
+         isa = "PBXFileReference";
+         path = "DependencyProviderRegistryTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_25" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_26"
+         );
+         name = "Pluginized";
+         path = "Pluginized";
+         sourceTree = "<group>";
+      };
+      "OBJ_26" = {
+         isa = "PBXFileReference";
+         path = "PluginizedComponentTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_27" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_28"
+         );
+         name = "NeedleFoundationTestTests";
+         path = "Tests/NeedleFoundationTestTests";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_28" = {
+         isa = "PBXFileReference";
+         path = "MockComponentPathBuilderTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_29" = {
+         isa = "PBXFileReference";
+         path = "Images";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_3" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "NO";
+            DEBUG_INFORMATION_FORMAT = "dwarf";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            ENABLE_NS_ASSERTIONS = "YES";
+            GCC_OPTIMIZATION_LEVEL = "0";
+            GCC_PREPROCESSOR_DEFINITIONS = (
+               "DEBUG=1",
+               "$(inherited)"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            ONLY_ACTIVE_ARCH = "YES";
+            OTHER_SWIFT_FLAGS = (
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "SWIFT_PACKAGE",
+               "DEBUG"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Debug";
+      };
+      "OBJ_30" = {
+         isa = "PBXFileReference";
+         path = "Generator";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_31" = {
+         isa = "PBXFileReference";
+         path = "Sample";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_32" = {
+         isa = "PBXGroup";
+         children = (
+            "NeedleFoundation::NeedleFoundation::Product",
+            "NeedleFoundation::NeedleFoundationTestTests::Product",
+            "NeedleFoundation::NeedleFoundationTests::Product",
+            "NeedleFoundation::NeedleFoundationTest::Product"
+         );
+         name = "Products";
+         path = "";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "OBJ_38" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_39",
+            "OBJ_40"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_39" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundation";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundation";
+         };
+         name = "Debug";
+      };
+      "OBJ_4" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "YES";
+            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            GCC_OPTIMIZATION_LEVEL = "s";
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_SWIFT_FLAGS = (
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "SWIFT_PACKAGE"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Release";
+      };
+      "OBJ_40" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundation";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundation";
+         };
+         name = "Release";
+      };
+      "OBJ_41" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_42",
+            "OBJ_43",
+            "OBJ_44",
+            "OBJ_45",
+            "OBJ_46",
+            "OBJ_47",
+            "OBJ_48"
+         );
+      };
+      "OBJ_42" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_9";
+      };
+      "OBJ_43" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_10";
+      };
+      "OBJ_44" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_12";
+      };
+      "OBJ_45" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_15";
+      };
+      "OBJ_46" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_16";
+      };
+      "OBJ_47" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_17";
+      };
+      "OBJ_48" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_18";
+      };
+      "OBJ_49" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_5" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_6",
+            "OBJ_7",
+            "OBJ_21",
+            "OBJ_29",
+            "OBJ_30",
+            "OBJ_31",
+            "OBJ_32"
+         );
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_51" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_52",
+            "OBJ_53"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_52" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_53" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Release";
+      };
+      "OBJ_54" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_55"
+         );
+      };
+      "OBJ_55" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_6";
+      };
+      "OBJ_57" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_58",
+            "OBJ_59"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_58" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Debug";
+      };
+      "OBJ_59" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Release";
+      };
+      "OBJ_6" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         path = "Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_60" = {
+         isa = "PBXTargetDependency";
+         target = "NeedleFoundation::NeedleFoundationTestTests";
+      };
+      "OBJ_62" = {
+         isa = "PBXTargetDependency";
+         target = "NeedleFoundation::NeedleFoundationTests";
+      };
+      "OBJ_65" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_66",
+            "OBJ_67"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_66" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundationTest";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundationTest";
+         };
+         name = "Debug";
+      };
+      "OBJ_67" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundationTest";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundationTest";
+         };
+         name = "Release";
+      };
+      "OBJ_68" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_69"
+         );
+      };
+      "OBJ_69" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_20";
+      };
+      "OBJ_7" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_8",
+            "OBJ_19"
+         );
+         name = "Sources";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_70" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_71" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_72",
+            "OBJ_73"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_72" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundationTestTests";
+         };
+         name = "Debug";
+      };
+      "OBJ_73" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundationTestTests";
+         };
+         name = "Release";
+      };
+      "OBJ_74" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_75"
+         );
+      };
+      "OBJ_75" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_28";
+      };
+      "OBJ_76" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_77"
+         );
+      };
+      "OBJ_77" = {
+         isa = "PBXBuildFile";
+         fileRef = "NeedleFoundation::NeedleFoundationTest::Product";
+      };
+      "OBJ_78" = {
+         isa = "PBXTargetDependency";
+         target = "NeedleFoundation::NeedleFoundationTest";
+      };
+      "OBJ_79" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_80",
+            "OBJ_81"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_8" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_9",
+            "OBJ_10",
+            "OBJ_11",
+            "OBJ_13"
+         );
+         name = "NeedleFoundation";
+         path = "Sources/NeedleFoundation";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_80" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundationTests";
+         };
+         name = "Debug";
+      };
+      "OBJ_81" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "NeedleFoundationTests";
+         };
+         name = "Release";
+      };
+      "OBJ_82" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_83",
+            "OBJ_84",
+            "OBJ_85"
+         );
+      };
+      "OBJ_83" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_23";
+      };
+      "OBJ_84" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_24";
+      };
+      "OBJ_85" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_26";
+      };
+      "OBJ_86" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_87"
+         );
+      };
+      "OBJ_87" = {
+         isa = "PBXBuildFile";
+         fileRef = "NeedleFoundation::NeedleFoundation::Product";
+      };
+      "OBJ_88" = {
+         isa = "PBXTargetDependency";
+         target = "NeedleFoundation::NeedleFoundation";
+      };
+      "OBJ_9" = {
+         isa = "PBXFileReference";
+         path = "Bootstrap.swift";
+         sourceTree = "<group>";
+      };
+   };
+   rootObject = "OBJ_1";
 }

--- a/NeedleFoundation.xcodeproj/project.pbxproj
+++ b/NeedleFoundation.xcodeproj/project.pbxproj
@@ -1,947 +1,775 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      "NeedleFoundation::NeedleFoundation" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_38";
-         buildPhases = (
-            "OBJ_41",
-            "OBJ_49"
-         );
-         dependencies = (
-         );
-         name = "NeedleFoundation";
-         productName = "NeedleFoundation";
-         productReference = "NeedleFoundation::NeedleFoundation::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "NeedleFoundation::NeedleFoundation::Product" = {
-         isa = "PBXFileReference";
-         path = "NeedleFoundation.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" = {
-         isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_57";
-         buildPhases = (
-         );
-         dependencies = (
-            "OBJ_60",
-            "OBJ_62"
-         );
-         name = "NeedleFoundationPackageTests";
-         productName = "NeedleFoundationPackageTests";
-      };
-      "NeedleFoundation::NeedleFoundationTest" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_65";
-         buildPhases = (
-            "OBJ_68",
-            "OBJ_70"
-         );
-         dependencies = (
-         );
-         name = "NeedleFoundationTest";
-         productName = "NeedleFoundationTest";
-         productReference = "NeedleFoundation::NeedleFoundationTest::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "NeedleFoundation::NeedleFoundationTest::Product" = {
-         isa = "PBXFileReference";
-         path = "NeedleFoundationTest.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "NeedleFoundation::NeedleFoundationTestTests" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_71";
-         buildPhases = (
-            "OBJ_74",
-            "OBJ_76"
-         );
-         dependencies = (
-            "OBJ_78"
-         );
-         name = "NeedleFoundationTestTests";
-         productName = "NeedleFoundationTestTests";
-         productReference = "NeedleFoundation::NeedleFoundationTestTests::Product";
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      "NeedleFoundation::NeedleFoundationTestTests::Product" = {
-         isa = "PBXFileReference";
-         path = "NeedleFoundationTestTests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "NeedleFoundation::NeedleFoundationTests" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_79";
-         buildPhases = (
-            "OBJ_82",
-            "OBJ_86"
-         );
-         dependencies = (
-            "OBJ_88"
-         );
-         name = "NeedleFoundationTests";
-         productName = "NeedleFoundationTests";
-         productReference = "NeedleFoundation::NeedleFoundationTests::Product";
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      "NeedleFoundation::NeedleFoundationTests::Product" = {
-         isa = "PBXFileReference";
-         path = "NeedleFoundationTests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "NeedleFoundation::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_51";
-         buildPhases = (
-            "OBJ_54"
-         );
-         dependencies = (
-         );
-         name = "NeedleFoundationPackageDescription";
-         productName = "NeedleFoundationPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "OBJ_1" = {
-         isa = "PBXProject";
-         attributes = {
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = "OBJ_2";
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "English";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en"
-         );
-         mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_32";
-         projectDirPath = ".";
-         targets = (
-            "NeedleFoundation::NeedleFoundation",
-            "NeedleFoundation::SwiftPMPackageDescription",
-            "NeedleFoundation::NeedleFoundationPackageTests::ProductTarget",
-            "NeedleFoundation::NeedleFoundationTest",
-            "NeedleFoundation::NeedleFoundationTestTests",
-            "NeedleFoundation::NeedleFoundationTests"
-         );
-      };
-      "OBJ_10" = {
-         isa = "PBXFileReference";
-         path = "Component.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_11" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_12"
-         );
-         name = "Internal";
-         path = "Internal";
-         sourceTree = "<group>";
-      };
-      "OBJ_12" = {
-         isa = "PBXFileReference";
-         path = "DependencyProviderRegistry.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_13" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_14",
-            "OBJ_16",
-            "OBJ_17",
-            "OBJ_18"
-         );
-         name = "Pluginized";
-         path = "Pluginized";
-         sourceTree = "<group>";
-      };
-      "OBJ_14" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_15"
-         );
-         name = "Internal";
-         path = "Internal";
-         sourceTree = "<group>";
-      };
-      "OBJ_15" = {
-         isa = "PBXFileReference";
-         path = "PluginExtensionProviderRegistry.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_16" = {
-         isa = "PBXFileReference";
-         path = "NonCoreComponent.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_17" = {
-         isa = "PBXFileReference";
-         path = "PluginizedComponent.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_18" = {
-         isa = "PBXFileReference";
-         path = "PluginizedScopeLifecycle.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_19" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_20"
-         );
-         name = "NeedleFoundationTest";
-         path = "Sources/NeedleFoundationTest";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_2" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_3",
-            "OBJ_4"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_20" = {
-         isa = "PBXFileReference";
-         path = "MockComponentPathBuilder.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_21" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_22",
-            "OBJ_27"
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_22" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_23",
-            "OBJ_24",
-            "OBJ_25"
-         );
-         name = "NeedleFoundationTests";
-         path = "Tests/NeedleFoundationTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_23" = {
-         isa = "PBXFileReference";
-         path = "ComponentTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_24" = {
-         isa = "PBXFileReference";
-         path = "DependencyProviderRegistryTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_25" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_26"
-         );
-         name = "Pluginized";
-         path = "Pluginized";
-         sourceTree = "<group>";
-      };
-      "OBJ_26" = {
-         isa = "PBXFileReference";
-         path = "PluginizedComponentTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_27" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_28"
-         );
-         name = "NeedleFoundationTestTests";
-         path = "Tests/NeedleFoundationTestTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_28" = {
-         isa = "PBXFileReference";
-         path = "MockComponentPathBuilderTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_29" = {
-         isa = "PBXFileReference";
-         path = "Images";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_3" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "DEBUG=1",
-               "$(inherited)"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "SWIFT_PACKAGE",
-               "DEBUG"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      "OBJ_30" = {
-         isa = "PBXFileReference";
-         path = "Generator";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_31" = {
-         isa = "PBXFileReference";
-         path = "Sample";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_32" = {
-         isa = "PBXGroup";
-         children = (
-            "NeedleFoundation::NeedleFoundation::Product",
-            "NeedleFoundation::NeedleFoundationTestTests::Product",
-            "NeedleFoundation::NeedleFoundationTests::Product",
-            "NeedleFoundation::NeedleFoundationTest::Product"
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_38" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_39",
-            "OBJ_40"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_39" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundation";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundation";
-         };
-         name = "Debug";
-      };
-      "OBJ_4" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "SWIFT_PACKAGE"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      "OBJ_40" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundation";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundation";
-         };
-         name = "Release";
-      };
-      "OBJ_41" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_42",
-            "OBJ_43",
-            "OBJ_44",
-            "OBJ_45",
-            "OBJ_46",
-            "OBJ_47",
-            "OBJ_48"
-         );
-      };
-      "OBJ_42" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_9";
-      };
-      "OBJ_43" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
-      };
-      "OBJ_44" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
-      };
-      "OBJ_45" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
-      };
-      "OBJ_46" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
-      };
-      "OBJ_47" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_17";
-      };
-      "OBJ_48" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_18";
-      };
-      "OBJ_49" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_21",
-            "OBJ_29",
-            "OBJ_30",
-            "OBJ_31",
-            "OBJ_32"
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_51" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_52",
-            "OBJ_53"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_52" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_53" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Release";
-      };
-      "OBJ_54" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_55"
-         );
-      };
-      "OBJ_55" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_57" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_58",
-            "OBJ_59"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_58" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Debug";
-      };
-      "OBJ_59" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Release";
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_60" = {
-         isa = "PBXTargetDependency";
-         target = "NeedleFoundation::NeedleFoundationTestTests";
-      };
-      "OBJ_62" = {
-         isa = "PBXTargetDependency";
-         target = "NeedleFoundation::NeedleFoundationTests";
-      };
-      "OBJ_65" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_66",
-            "OBJ_67"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_66" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundationTest";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundationTest";
-         };
-         name = "Debug";
-      };
-      "OBJ_67" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "NeedleFoundationTest";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundationTest";
-         };
-         name = "Release";
-      };
-      "OBJ_68" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_69"
-         );
-      };
-      "OBJ_69" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
-      };
-      "OBJ_7" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_8",
-            "OBJ_19"
-         );
-         name = "Sources";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_70" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_71" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_72",
-            "OBJ_73"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_72" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundationTestTests";
-         };
-         name = "Debug";
-      };
-      "OBJ_73" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundationTestTests";
-         };
-         name = "Release";
-      };
-      "OBJ_74" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_75"
-         );
-      };
-      "OBJ_75" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
-      };
-      "OBJ_76" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_77"
-         );
-      };
-      "OBJ_77" = {
-         isa = "PBXBuildFile";
-         fileRef = "NeedleFoundation::NeedleFoundationTest::Product";
-      };
-      "OBJ_78" = {
-         isa = "PBXTargetDependency";
-         target = "NeedleFoundation::NeedleFoundationTest";
-      };
-      "OBJ_79" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_80",
-            "OBJ_81"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_8" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_9",
-            "OBJ_10",
-            "OBJ_11",
-            "OBJ_13"
-         );
-         name = "NeedleFoundation";
-         path = "Sources/NeedleFoundation";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_80" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundationTests";
-         };
-         name = "Debug";
-      };
-      "OBJ_81" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "NeedleFoundationTests";
-         };
-         name = "Release";
-      };
-      "OBJ_82" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_83",
-            "OBJ_84",
-            "OBJ_85"
-         );
-      };
-      "OBJ_83" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_23";
-      };
-      "OBJ_84" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
-      };
-      "OBJ_85" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
-      };
-      "OBJ_86" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_87"
-         );
-      };
-      "OBJ_87" = {
-         isa = "PBXBuildFile";
-         fileRef = "NeedleFoundation::NeedleFoundation::Product";
-      };
-      "OBJ_88" = {
-         isa = "PBXTargetDependency";
-         target = "NeedleFoundation::NeedleFoundation";
-      };
-      "OBJ_9" = {
-         isa = "PBXFileReference";
-         path = "Bootstrap.swift";
-         sourceTree = "<group>";
-      };
-   };
-   rootObject = "OBJ_1";
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" /* NeedleFoundationPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_57 /* Build configuration list for PBXAggregateTarget "NeedleFoundationPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_60 /* PBXTargetDependency */,
+				OBJ_62 /* PBXTargetDependency */,
+			);
+			name = NeedleFoundationPackageTests;
+			productName = NeedleFoundationPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		OBJ_42 /* Bootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Bootstrap.swift */; };
+		OBJ_43 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Component.swift */; };
+		OBJ_44 /* DependencyProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* DependencyProviderRegistry.swift */; };
+		OBJ_45 /* PluginExtensionProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* PluginExtensionProviderRegistry.swift */; };
+		OBJ_46 /* NonCoreComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* NonCoreComponent.swift */; };
+		OBJ_47 /* PluginizedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* PluginizedComponent.swift */; };
+		OBJ_48 /* PluginizedScopeLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* PluginizedScopeLifecycle.swift */; };
+		OBJ_55 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_69 /* MockComponentPathBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* MockComponentPathBuilder.swift */; };
+		OBJ_75 /* MockComponentPathBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* MockComponentPathBuilderTests.swift */; };
+		OBJ_77 /* NeedleFoundationTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "NeedleFoundation::NeedleFoundationTest::Product" /* NeedleFoundationTest.framework */; };
+		OBJ_83 /* ComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* ComponentTests.swift */; };
+		OBJ_84 /* DependencyProviderRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* DependencyProviderRegistryTests.swift */; };
+		OBJ_85 /* PluginizedComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* PluginizedComponentTests.swift */; };
+		OBJ_87 /* NeedleFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		BCD469F9228F54C300368FC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundation";
+			remoteInfo = NeedleFoundation;
+		};
+		BCD469FA228F54C400368FC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTest";
+			remoteInfo = NeedleFoundationTest;
+		};
+		BCD469FB228F54C800368FC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTestTests";
+			remoteInfo = NeedleFoundationTestTests;
+		};
+		BCD469FC228F54C800368FC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTests";
+			remoteInfo = NeedleFoundationTests;
+		};
+		BCD469FD2293199800368FC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundation";
+			remoteInfo = NeedleFoundation;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		"NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = NeedleFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"NeedleFoundation::NeedleFoundationTest::Product" /* NeedleFoundationTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = NeedleFoundationTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"NeedleFoundation::NeedleFoundationTestTests::Product" /* NeedleFoundationTestTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = NeedleFoundationTestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = NeedleFoundationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_10 /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
+		OBJ_12 /* DependencyProviderRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyProviderRegistry.swift; sourceTree = "<group>"; };
+		OBJ_15 /* PluginExtensionProviderRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginExtensionProviderRegistry.swift; sourceTree = "<group>"; };
+		OBJ_16 /* NonCoreComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonCoreComponent.swift; sourceTree = "<group>"; };
+		OBJ_17 /* PluginizedComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginizedComponent.swift; sourceTree = "<group>"; };
+		OBJ_18 /* PluginizedScopeLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginizedScopeLifecycle.swift; sourceTree = "<group>"; };
+		OBJ_20 /* MockComponentPathBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockComponentPathBuilder.swift; sourceTree = "<group>"; };
+		OBJ_23 /* ComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentTests.swift; sourceTree = "<group>"; };
+		OBJ_24 /* DependencyProviderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyProviderRegistryTests.swift; sourceTree = "<group>"; };
+		OBJ_26 /* PluginizedComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginizedComponentTests.swift; sourceTree = "<group>"; };
+		OBJ_28 /* MockComponentPathBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockComponentPathBuilderTests.swift; sourceTree = "<group>"; };
+		OBJ_29 /* Images */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Images; sourceTree = SOURCE_ROOT; };
+		OBJ_30 /* Generator */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Generator; sourceTree = SOURCE_ROOT; };
+		OBJ_31 /* Sample */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Sample; sourceTree = SOURCE_ROOT; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_9 /* Bootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bootstrap.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_49 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_70 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_76 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_77 /* NeedleFoundationTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_86 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_87 /* NeedleFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_11 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_12 /* DependencyProviderRegistry.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		OBJ_13 /* Pluginized */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_14 /* Internal */,
+				OBJ_16 /* NonCoreComponent.swift */,
+				OBJ_17 /* PluginizedComponent.swift */,
+				OBJ_18 /* PluginizedScopeLifecycle.swift */,
+			);
+			path = Pluginized;
+			sourceTree = "<group>";
+		};
+		OBJ_14 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* PluginExtensionProviderRegistry.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		OBJ_19 /* NeedleFoundationTest */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_20 /* MockComponentPathBuilder.swift */,
+			);
+			name = NeedleFoundationTest;
+			path = Sources/NeedleFoundationTest;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_21 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_22 /* NeedleFoundationTests */,
+				OBJ_27 /* NeedleFoundationTestTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_22 /* NeedleFoundationTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_23 /* ComponentTests.swift */,
+				OBJ_24 /* DependencyProviderRegistryTests.swift */,
+				OBJ_25 /* Pluginized */,
+			);
+			name = NeedleFoundationTests;
+			path = Tests/NeedleFoundationTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_25 /* Pluginized */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_26 /* PluginizedComponentTests.swift */,
+			);
+			path = Pluginized;
+			sourceTree = "<group>";
+		};
+		OBJ_27 /* NeedleFoundationTestTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_28 /* MockComponentPathBuilderTests.swift */,
+			);
+			name = NeedleFoundationTestTests;
+			path = Tests/NeedleFoundationTestTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_32 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */,
+				"NeedleFoundation::NeedleFoundationTestTests::Product" /* NeedleFoundationTestTests.xctest */,
+				"NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */,
+				"NeedleFoundation::NeedleFoundationTest::Product" /* NeedleFoundationTest.framework */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_21 /* Tests */,
+				OBJ_29 /* Images */,
+				OBJ_30 /* Generator */,
+				OBJ_31 /* Sample */,
+				OBJ_32 /* Products */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* NeedleFoundation */,
+				OBJ_19 /* NeedleFoundationTest */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* NeedleFoundation */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Bootstrap.swift */,
+				OBJ_10 /* Component.swift */,
+				OBJ_11 /* Internal */,
+				OBJ_13 /* Pluginized */,
+			);
+			name = NeedleFoundation;
+			path = Sources/NeedleFoundation;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"NeedleFoundation::NeedleFoundation" /* NeedleFoundation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_38 /* Build configuration list for PBXNativeTarget "NeedleFoundation" */;
+			buildPhases = (
+				OBJ_41 /* Sources */,
+				OBJ_49 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NeedleFoundation;
+			productName = NeedleFoundation;
+			productReference = "NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"NeedleFoundation::NeedleFoundationTest" /* NeedleFoundationTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_65 /* Build configuration list for PBXNativeTarget "NeedleFoundationTest" */;
+			buildPhases = (
+				OBJ_68 /* Sources */,
+				OBJ_70 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BCD469FE2293199800368FC0 /* PBXTargetDependency */,
+			);
+			name = NeedleFoundationTest;
+			productName = NeedleFoundationTest;
+			productReference = "NeedleFoundation::NeedleFoundationTest::Product" /* NeedleFoundationTest.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"NeedleFoundation::NeedleFoundationTestTests" /* NeedleFoundationTestTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_71 /* Build configuration list for PBXNativeTarget "NeedleFoundationTestTests" */;
+			buildPhases = (
+				OBJ_74 /* Sources */,
+				OBJ_76 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_78 /* PBXTargetDependency */,
+			);
+			name = NeedleFoundationTestTests;
+			productName = NeedleFoundationTestTests;
+			productReference = "NeedleFoundation::NeedleFoundationTestTests::Product" /* NeedleFoundationTestTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_79 /* Build configuration list for PBXNativeTarget "NeedleFoundationTests" */;
+			buildPhases = (
+				OBJ_82 /* Sources */,
+				OBJ_86 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_88 /* PBXTargetDependency */,
+			);
+			name = NeedleFoundationTests;
+			productName = NeedleFoundationTests;
+			productReference = "NeedleFoundation::NeedleFoundationTests::Product" /* NeedleFoundationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"NeedleFoundation::SwiftPMPackageDescription" /* NeedleFoundationPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_51 /* Build configuration list for PBXNativeTarget "NeedleFoundationPackageDescription" */;
+			buildPhases = (
+				OBJ_54 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NeedleFoundationPackageDescription;
+			productName = NeedleFoundationPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "NeedleFoundation" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_32 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"NeedleFoundation::NeedleFoundation" /* NeedleFoundation */,
+				"NeedleFoundation::SwiftPMPackageDescription" /* NeedleFoundationPackageDescription */,
+				"NeedleFoundation::NeedleFoundationPackageTests::ProductTarget" /* NeedleFoundationPackageTests */,
+				"NeedleFoundation::NeedleFoundationTest" /* NeedleFoundationTest */,
+				"NeedleFoundation::NeedleFoundationTestTests" /* NeedleFoundationTestTests */,
+				"NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_41 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_42 /* Bootstrap.swift in Sources */,
+				OBJ_43 /* Component.swift in Sources */,
+				OBJ_44 /* DependencyProviderRegistry.swift in Sources */,
+				OBJ_45 /* PluginExtensionProviderRegistry.swift in Sources */,
+				OBJ_46 /* NonCoreComponent.swift in Sources */,
+				OBJ_47 /* PluginizedComponent.swift in Sources */,
+				OBJ_48 /* PluginizedScopeLifecycle.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_55 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_68 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_69 /* MockComponentPathBuilder.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_74 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_75 /* MockComponentPathBuilderTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_82 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_83 /* ComponentTests.swift in Sources */,
+				OBJ_84 /* DependencyProviderRegistryTests.swift in Sources */,
+				OBJ_85 /* PluginizedComponentTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BCD469FE2293199800368FC0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "NeedleFoundation::NeedleFoundation" /* NeedleFoundation */;
+			targetProxy = BCD469FD2293199800368FC0 /* PBXContainerItemProxy */;
+		};
+		OBJ_60 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "NeedleFoundation::NeedleFoundationTestTests" /* NeedleFoundationTestTests */;
+			targetProxy = BCD469FB228F54C800368FC0 /* PBXContainerItemProxy */;
+		};
+		OBJ_62 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "NeedleFoundation::NeedleFoundationTests" /* NeedleFoundationTests */;
+			targetProxy = BCD469FC228F54C800368FC0 /* PBXContainerItemProxy */;
+		};
+		OBJ_78 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "NeedleFoundation::NeedleFoundationTest" /* NeedleFoundationTest */;
+			targetProxy = BCD469FA228F54C400368FC0 /* PBXContainerItemProxy */;
+		};
+		OBJ_88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "NeedleFoundation::NeedleFoundation" /* NeedleFoundation */;
+			targetProxy = BCD469F9228F54C300368FC0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_39 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = NeedleFoundation;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundation;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_40 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = NeedleFoundation;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundation;
+			};
+			name = Release;
+		};
+		OBJ_52 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_53 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.10.1.0.10B61.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_58 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_59 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_66 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = NeedleFoundationTest;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundationTest;
+			};
+			name = Debug;
+		};
+		OBJ_67 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTest_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = NeedleFoundationTest;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundationTest;
+			};
+			name = Release;
+		};
+		OBJ_72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundationTestTests;
+			};
+			name = Debug;
+		};
+		OBJ_73 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTestTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundationTestTests;
+			};
+			name = Release;
+		};
+		OBJ_80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundationTests;
+			};
+			name = Debug;
+		};
+		OBJ_81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundationTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = NeedleFoundationTests;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_2 /* Build configuration list for PBXProject "NeedleFoundation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_38 /* Build configuration list for PBXNativeTarget "NeedleFoundation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_39 /* Debug */,
+				OBJ_40 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_51 /* Build configuration list for PBXNativeTarget "NeedleFoundationPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_52 /* Debug */,
+				OBJ_53 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_57 /* Build configuration list for PBXAggregateTarget "NeedleFoundationPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_58 /* Debug */,
+				OBJ_59 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_65 /* Build configuration list for PBXNativeTarget "NeedleFoundationTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_66 /* Debug */,
+				OBJ_67 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_71 /* Build configuration list for PBXNativeTarget "NeedleFoundationTestTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_72 /* Debug */,
+				OBJ_73 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_79 /* Build configuration list for PBXNativeTarget "NeedleFoundationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_80 /* Debug */,
+				OBJ_81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundation-Package.xcscheme
+++ b/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundation-Package.xcscheme
@@ -14,6 +14,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTest"
+               BuildableName = "NeedleFoundationTest.framework"
+               BlueprintName = "NeedleFoundationTest"
+               ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "NeedleFoundation::NeedleFoundation"
                BuildableName = "NeedleFoundation.framework"
                BlueprintName = "NeedleFoundation"
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTestTests"
+               BuildableName = "NeedleFoundationTestTests.xctest"
+               BlueprintName = "NeedleFoundationTestTests"
+               ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference
@@ -55,9 +79,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NeedleFoundation::NeedleFoundation"
-            BuildableName = "NeedleFoundation.framework"
-            BlueprintName = "NeedleFoundation"
+            BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTest"
+            BuildableName = "NeedleFoundationTest.framework"
+            BlueprintName = "NeedleFoundationTest"
             ReferencedContainer = "container:NeedleFoundation.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundationTest.xcscheme
+++ b/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundationTest.xcscheme
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTest"
+               BuildableName = "NeedleFoundationTest.framework"
+               BlueprintName = "NeedleFoundationTest"
+               ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NeedleFoundation::NeedleFoundation"
+            BuildableName = "NeedleFoundation.framework"
+            BlueprintName = "NeedleFoundation"
+            ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundationTestTests.xcscheme
+++ b/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundationTestTests.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTestTests"
+               BuildableName = "NeedleFoundationTestTests.xctest"
+               BlueprintName = "NeedleFoundationTestTests"
+               ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTestTests"
+               BuildableName = "NeedleFoundationTestTests.xctest"
+               BlueprintName = "NeedleFoundationTestTests"
+               ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTestTests"
+            BuildableName = "NeedleFoundationTestTests.xctest"
+            BlueprintName = "NeedleFoundationTestTests"
+            ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTestTests"
+            BuildableName = "NeedleFoundationTestTests.xctest"
+            BlueprintName = "NeedleFoundationTestTests"
+            ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTestTests"
+            BuildableName = "NeedleFoundationTestTests.xctest"
+            BlueprintName = "NeedleFoundationTestTests"
+            ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "NeedleFoundation",
     products: [
-        .library(name: "NeedleFoundation", targets: ["NeedleFoundation"])
+        .library(name: "NeedleFoundation", targets: ["NeedleFoundation"]),
+        .library(name: "NeedleFoundationTest", targets: ["NeedleFoundationTest"])
     ],
     dependencies: [],
     targets: [
@@ -14,6 +15,13 @@ let package = Package(
         .testTarget(
             name: "NeedleFoundationTests",
             dependencies: ["NeedleFoundation"],
+            exclude: []),
+        .target(
+            name: "NeedleFoundationTest",
+            dependencies: []),
+        .testTarget(
+            name: "NeedleFoundationTestTests",
+            dependencies: ["NeedleFoundationTest"],
             exclude: []),
     ],
     swiftLanguageVersions: [4]

--- a/Sample/MVC/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
+++ b/Sample/MVC/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
@@ -58,6 +58,20 @@
 			remoteGlobalIDString = "NeedleFoundation::NeedleFoundation";
 			remoteInfo = NeedleFoundation;
 		};
+		BC1FD60E229320730077EEF3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4140797421F808230081B8A9 /* NeedleFoundation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTest::Product";
+			remoteInfo = NeedleFoundationTest;
+		};
+		BC1FD610229320730077EEF3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4140797421F808230081B8A9 /* NeedleFoundation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTestTests::Product";
+			remoteInfo = NeedleFoundationTestTests;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -207,6 +221,8 @@
 			isa = PBXGroup;
 			children = (
 				4140797C21F808230081B8A9 /* NeedleFoundation.framework */,
+				BC1FD60F229320730077EEF3 /* NeedleFoundationTest.framework */,
+				BC1FD611229320730077EEF3 /* NeedleFoundationTestTests.xctest */,
 				4140797E21F808230081B8A9 /* NeedleFoundationTests.xctest */,
 			);
 			name = Products;
@@ -319,6 +335,20 @@
 			fileType = file;
 			path = NeedleFoundationTests.xctest;
 			remoteRef = 4140797D21F808230081B8A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC1FD60F229320730077EEF3 /* NeedleFoundationTest.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = NeedleFoundationTest.framework;
+			remoteRef = BC1FD60E229320730077EEF3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC1FD611229320730077EEF3 /* NeedleFoundationTestTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = file;
+			path = NeedleFoundationTestTests.xctest;
+			remoteRef = BC1FD610229320730077EEF3 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -503,7 +533,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -558,7 +588,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
+++ b/Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
@@ -117,6 +117,20 @@
 			remoteGlobalIDString = "NeedleFoundation::NeedleFoundation";
 			remoteInfo = NeedleFoundation;
 		};
+		BC3008AE2293247E00032FE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 41F6882821F802A000AA3CCA /* NeedleFoundation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTest::Product";
+			remoteInfo = NeedleFoundationTest;
+		};
+		BC3008B02293247E00032FE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 41F6882821F802A000AA3CCA /* NeedleFoundation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "NeedleFoundation::NeedleFoundationTestTests::Product";
+			remoteInfo = NeedleFoundationTestTests;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -352,6 +366,8 @@
 			isa = PBXGroup;
 			children = (
 				41F6882E21F802A000AA3CCA /* NeedleFoundation.framework */,
+				BC3008AF2293247E00032FE3 /* NeedleFoundationTest.framework */,
+				BC3008B12293247E00032FE3 /* NeedleFoundationTestTests.xctest */,
 				41F6883021F802A000AA3CCA /* NeedleFoundationTests.xctest */,
 			);
 			name = Products;
@@ -544,9 +560,23 @@
 		};
 		41F6883021F802A000AA3CCA /* NeedleFoundationTests.xctest */ = {
 			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
+			fileType = file;
 			path = NeedleFoundationTests.xctest;
 			remoteRef = 41F6882F21F802A000AA3CCA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC3008AF2293247E00032FE3 /* NeedleFoundationTest.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = NeedleFoundationTest.framework;
+			remoteRef = BC3008AE2293247E00032FE3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BC3008B12293247E00032FE3 /* NeedleFoundationTestTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = file;
+			path = NeedleFoundationTestTests.xctest;
+			remoteRef = BC3008B02293247E00032FE3 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -968,7 +998,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1023,7 +1053,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/Sources/NeedleFoundation/Internal/DependencyProviderRegistry.swift
+++ b/Sources/NeedleFoundation/Internal/DependencyProviderRegistry.swift
@@ -48,6 +48,19 @@ public class __DependencyProviderRegistry {
         providerFactories[componentPath.hashValue] = dependencyProviderFactory
     }
 
+    /// Unregister the given factory closure with given key.
+    ///
+    /// - note: This method is thread-safe.
+    /// - parameter componentPath: The dependency graph path of the component
+    /// the provider is for.
+    public func unregisterDependencyProviderFactory(`for` componentPath: String) {
+        providerFactoryLock.lock()
+        defer {
+            providerFactoryLock.unlock()
+        }
+        providerFactories.removeValue(forKey: componentPath.hashValue)
+    }
+
     /// Retrieve the dependency provider for the given component and its parent.
     ///
     /// - parameter component: The component that uses the returned dependency provider.
@@ -66,6 +79,19 @@ public class __DependencyProviderRegistry {
             // This is useful for Needle generator development only.
             fatalError("Missing dependency provider factory for \(component.path)")
         }
+    }
+
+    /// Retrieve the dependency provider for the given componentpath.
+    ///
+    /// - parameter componentpath: The component path that uses the returned dependency provider.
+    /// - returns: The dependency provider for the given componentpath.
+    public func dependencyProviderFactory(`for` componentPath: String) -> ((Scope) -> AnyObject)? {
+        providerFactoryLock.lock()
+        defer {
+            providerFactoryLock.unlock()
+        }
+        
+        return providerFactories[componentPath.hashValue]
     }
 
     private let providerFactoryLock = NSRecursiveLock()

--- a/Sources/NeedleFoundationTest/MockComponentPathBuilder.swift
+++ b/Sources/NeedleFoundationTest/MockComponentPathBuilder.swift
@@ -1,0 +1,99 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+
+import Foundation
+import NeedleFoundation
+
+/// This function allows you to get access to a mock component path builder that you can use to
+/// build mock component paths of type MockComponentPath. You can use these paths to register mock
+/// dependency providers during testing.
+///
+/// - Returns: A mock component path builder.
+public func mockComponentPathBuilder() -> MockComponentPathBuilder {
+    return MockComponentPathBuilder(dependencyProviderRegistry:  __DependencyProviderRegistry.instance)
+}
+
+/// MockComponentPathBuilder aloows you to build a component path that mirrors the ancestry of a component.
+/// Once the path is created, you can invoke build to create an instance of MockComponentPath. This class is not
+/// intended to be subclassed.
+public final class MockComponentPathBuilder {
+    private let dependencyProviderRegistry: __DependencyProviderRegistry
+    private var path: [String] = ["^"]
+    fileprivate init(dependencyProviderRegistry: __DependencyProviderRegistry) {
+        self.dependencyProviderRegistry = dependencyProviderRegistry
+    }
+    
+    /// Extend the component path from the leaf component in the current component path to its next child
+    /// in the ancestry tree.
+    ///
+    /// - Parameter componentType: Type of the component.
+    /// - Returns: Instance of the mock component path builder that has the path extended up to `componentType`.
+    public func extendPath(to componentType: Scope.Type) -> MockComponentPathBuilder {
+        let fullyQualifiedSelfName = String(describing: componentType)
+        let parts = fullyQualifiedSelfName.components(separatedBy: ".")
+        let nodeName = parts.last ?? fullyQualifiedSelfName
+        path.append(nodeName)
+        return self
+    }
+    
+    /// Build the mock component path based.
+    ///
+    /// - Returns: The mock component path built based on the settings provided to the mock component path builder.
+    public func build() -> MockComponentPath {
+        return MockComponentPath(path: pathString(), dependencyProviderRegistry: dependencyProviderRegistry)
+    }
+    
+    private func pathString() -> String {
+        return path.joined(separator: "->")
+    }
+}
+
+/// This class represents the mocked component path that describes the ancestory of a component.
+/// This can be used to register a mock dependency provider for the component. This class is not
+/// intended to be subclassed.
+public final class MockComponentPath {
+    private let path: String
+    private let dependencyProviderRegistry: __DependencyProviderRegistry
+    private var preexistingDependencyProviderFactory: ((Scope) -> AnyObject)? = nil
+    private var canUnregister = false
+    fileprivate init(path: String, dependencyProviderRegistry: __DependencyProviderRegistry) {
+        self.path = path
+        self.dependencyProviderRegistry = dependencyProviderRegistry
+    }
+    
+    /// Register a dependency provider for the mocked component path.
+    ///
+    /// - Parameter dependencyProvider: The dependency provider to handle dependencies for the component.
+    public func register(dependencyProvider: AnyObject) {
+        preexistingDependencyProviderFactory = dependencyProviderRegistry.dependencyProviderFactory(for: path)
+        dependencyProviderRegistry.registerDependencyProviderFactory(for: path) { _ in
+            return dependencyProvider
+        }
+        canUnregister = true
+    }
+    
+    /// Unregister a previously registered dependency provider for the mocked component path.
+    public func unregister() {
+        guard canUnregister else { return }
+        dependencyProviderRegistry.unregisterDependencyProviderFactory(for: path)
+        if let preexistingDependencyProviderFactory = preexistingDependencyProviderFactory {
+            dependencyProviderRegistry.registerDependencyProviderFactory(for: path, preexistingDependencyProviderFactory)
+            self.preexistingDependencyProviderFactory = nil
+        }
+        canUnregister = false
+    }
+}

--- a/Tests/NeedleFoundationTestTests/MockComponentPathBuilderTests.swift
+++ b/Tests/NeedleFoundationTestTests/MockComponentPathBuilderTests.swift
@@ -1,0 +1,212 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import NeedleFoundation
+@testable import NeedleFoundationTest
+
+class MockComponentPathBuilderTests: XCTestCase {
+    class TestComponent2: TestComponent {}
+    class TestComponent3: TestComponent {}
+    class MockDependencyProvider: EmptyDependency {}
+    let mockBootstrapDependencyProvider = MockDependencyProvider()
+    let mockBootstrapComponentPath = mockComponentPathBuilder()
+        .extendPath(to: BootstrapComponent.self)
+        .build()
+
+    override func setUp() {
+        super.setUp()
+        mockBootstrapComponentPath.register(dependencyProvider: mockBootstrapDependencyProvider)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        mockBootstrapComponentPath.unregister()
+    }
+
+    func test_componentPathBuilder_verifyRegistration() {
+        let testDependencyProvider = MockDependencyProvider()
+        let componentPath = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .build()
+        componentPath.register(dependencyProvider: testDependencyProvider)
+        defer {
+            componentPath.unregister()
+        }
+        
+        let bootstrapComponent = BootstrapComponent()
+        let testComponent = TestComponent(parent: bootstrapComponent)
+        let retrievedDependencyProvider = __DependencyProviderRegistry.instance.dependencyProvider(for: testComponent)
+        XCTAssert(testDependencyProvider === retrievedDependencyProvider, "\nexpected: \(String(describing: testDependencyProvider))\ngot this:- \(String(describing: retrievedDependencyProvider))")
+    }
+    
+    func test_componentPathBuilder_withLongerComponentPath_verifyRegistration() {
+        let testDependencyProvider = MockDependencyProvider()
+        let componentPath1 = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .build()
+        componentPath1.register(dependencyProvider: testDependencyProvider)
+        let componentPath2 = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .extendPath(to: TestComponent2.self)
+            .build()
+        componentPath2.register(dependencyProvider: testDependencyProvider)
+        let componentPath3 = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .extendPath(to: TestComponent2.self)
+            .extendPath(to: TestComponent3.self)
+            .build()
+        componentPath3.register(dependencyProvider: testDependencyProvider)
+        defer {
+            componentPath1.unregister()
+            componentPath2.unregister()
+            componentPath3.unregister()
+        }
+        
+        let bootstrapComponent = BootstrapComponent()
+        let testComponent1 = TestComponent(parent: bootstrapComponent)
+        let testComponent2 = TestComponent2(parent: testComponent1)
+        let testComponent3 = TestComponent3(parent: testComponent2)
+        let retrievedDependencyProvider1 = __DependencyProviderRegistry.instance.dependencyProvider(for: testComponent1)
+        let retrievedDependencyProvider2 = __DependencyProviderRegistry.instance.dependencyProvider(for: testComponent2)
+        let retrievedDependencyProvider3 = __DependencyProviderRegistry.instance.dependencyProvider(for: testComponent3)
+        XCTAssert(retrievedDependencyProvider1 === testDependencyProvider, "\nexpected: \(String(describing: testDependencyProvider))\ngot this:- \(String(describing: retrievedDependencyProvider1))")
+        XCTAssert(retrievedDependencyProvider2 === testDependencyProvider, "\nexpected: \(String(describing: testDependencyProvider))\ngot this:- \(String(describing: retrievedDependencyProvider2))")
+        XCTAssert(retrievedDependencyProvider3 === testDependencyProvider, "\nexpected: \(String(describing: testDependencyProvider))\ngot this:- \(String(describing: retrievedDependencyProvider3))")
+    }
+    
+    func test_componentPathBuilder_unregister_verifyDependencyProvidersIsUnregistered() {
+        let testDependencyProvider = MockDependencyProvider()
+        let componentPath1 = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .build()
+        componentPath1.register(dependencyProvider: testDependencyProvider)
+        let componentPath2 = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .extendPath(to: TestComponent2.self)
+            .build()
+        componentPath2.register(dependencyProvider: testDependencyProvider)
+        
+        let bootstrapComponent = BootstrapComponent()
+        let testComponent1 = TestComponent(parent: bootstrapComponent)
+        let testComponent2 = TestComponent2(parent: testComponent1)
+        
+        let retrievedDependencyProvider = __DependencyProviderRegistry.instance.dependencyProvider(for: testComponent2)
+        XCTAssert(testDependencyProvider === retrievedDependencyProvider, "\nexpected: \(String(describing: testDependencyProvider))\ngot this:- \(String(describing: retrievedDependencyProvider))")
+        
+        let dependencyProviderRegistry = __DependencyProviderRegistry.instance
+        XCTAssertNotNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent->TestComponent2"), "We should get back the right dependency provider after invoking unregister")
+        // Unregistering the dependency provider for a component that DID NOT HAVE a pre-existing dependency provider
+        componentPath2.unregister()
+        XCTAssertNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent->TestComponent2"), "We should not get back the right dependency provider after invoking unregister")
+    }
+
+    func test_componentPathBuilder_unregister_verifyFallbackToPreviouslyRegisteredDependencyProvider() {
+        // Add a dependency provider for a path the old way
+        let path = "^->TestComponent"
+        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) { component in
+            return EmptyDependencyProvider.init(component: component)
+        }
+        let testDependencyProvider = MockDependencyProvider()
+        let componentPath1 = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .build()
+        componentPath1.register(dependencyProvider: testDependencyProvider)
+        
+        let bootstrapComponent = BootstrapComponent()
+        let testComponent1 = TestComponent(parent: bootstrapComponent)
+        
+        let retrievedDependencyProvider = __DependencyProviderRegistry.instance.dependencyProvider(for: testComponent1)
+        XCTAssert(testDependencyProvider === retrievedDependencyProvider, "\nexpected: \(String(describing: testDependencyProvider))\ngot this:- \(String(describing: retrievedDependencyProvider))")
+        
+        let dependencyProviderRegistry = __DependencyProviderRegistry.instance
+        XCTAssertNotNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent"), "We should get back the right dependency provider before invoking unregister")
+        // Unregistering the dependency provider for a component that HAD a pre-existing dependency provider
+        componentPath1.unregister()
+        XCTAssertNotNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent"), "We should get back the pre-exisitng dependency provider")
+        // Attempting to unregister the dependency provider for a component that had already been unregistered should
+        // not remove the pre-existing dependency provider.
+        componentPath1.unregister()
+        XCTAssertNotNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent"), "We should get back the pre-exisitng dependency provider")
+    }
+
+    func test_componentPathBuilder_unregister_verifyDoesNotUnregisterPrexistingDependencyProvider() {
+        // Add a dependency provider for a path the old way.
+        let path = "^->TestComponent"
+        // Register a dependency provider that will be treated as the pre-existing dependency provider.
+        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: path) { component in
+            return EmptyDependencyProvider.init(component: component)
+        }
+        let testDependencyProvider = MockDependencyProvider()
+        let componentPath1 = mockComponentPathBuilder()
+            .extendPath(to: BootstrapComponent.self)
+            .extendPath(to: TestComponent.self)
+            .build()
+        componentPath1.register(dependencyProvider: testDependencyProvider)
+        
+        let bootstrapComponent = BootstrapComponent()
+        let testComponent1 = TestComponent(parent: bootstrapComponent)
+        
+        let retrievedDependencyProvider = __DependencyProviderRegistry.instance.dependencyProvider(for: testComponent1)
+        XCTAssert(testDependencyProvider === retrievedDependencyProvider, "\nexpected: \(String(describing: testDependencyProvider))\ngot this:- \(String(describing: retrievedDependencyProvider))")
+        
+        let dependencyProviderRegistry = __DependencyProviderRegistry.instance
+        XCTAssertNotNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent"), "We should get back the right dependency provider before invoking unregister")
+        // Unregistering the dependency provider for a component that HAD a pre-existing dependency provider
+        componentPath1.unregister()
+        XCTAssertNotNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent"), "We should get back the pre-exisitng dependency provider")
+        // Attempting to unregister the dependency provider for a component that had already been unregistered should
+        // not remove the pre-existing dependency provider.
+        componentPath1.unregister()
+        XCTAssertNotNil(dependencyProviderRegistry.dependencyProviderFactory(for: "^->BootstrapComponent->TestComponent"), "We should get back the pre-exisitng dependency provider")
+    }
+}
+
+class TestComponent: Component<EmptyDependency> {
+    
+    fileprivate var callCount: Int = 0
+    fileprivate var expectedOptionalShare: ClassProtocol? = {
+        return ClassProtocolImpl()
+    }()
+    
+    var share: NSObject {
+        callCount += 1
+        return shared { NSObject() }
+    }
+    
+    var share2: NSObject {
+        return shared { NSObject() }
+    }
+    
+    fileprivate var optionalShare: ClassProtocol? {
+        return shared { self.expectedOptionalShare }
+    }
+}
+
+private protocol ClassProtocol: AnyObject {
+    
+}
+
+private class ClassProtocolImpl: ClassProtocol {
+    
+}


### PR DESCRIPTION
Addresses issue: #281

Only creating this to test build checks. This project was generated after adding an 11.4 sim locally, and xcode-selecting Xcode 10.1

Although the .travis.yml file contains NeedleFoundationTestTests target, we haven't yet added the target in the xcheme, so that build is expected to fail. Others should pass before we make further changes to the scheme.