### PR TITLE
Don't stop the moment we find a missing dependency

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
@@ -95,21 +95,21 @@ class DependencyGraphExporter {
     private func awaitSerialization(using taskHandleTuples: [(SequenceExecutionHandle<[SerializedProvider]>, String)], withTimeout timeout: TimeInterval) throws -> [SerializedProvider] {
         // Wait for all the generation to complete so we can write all the output into a single file
         var providers = [SerializedProvider]()
-        var missingDependencies = false
+        var isMissingDependencies = false
         for (taskHandle, componentName) in taskHandleTuples {
             do {
                 let provider = try taskHandle.await(withTimeout: timeout)
                 providers.append(contentsOf: provider)
             } catch DependencyProviderContentError.missingDependency(let message) {
                 warning(message)
-                missingDependencies = true
+                isMissingDependencies = true
             } catch SequenceExecutionError.awaitTimeout  {
                 throw GenericError.withMessage("Generating dependency provider for \(componentName) timed out.")
             } catch {
                 throw error
             }
         }
-        if missingDependencies {
+        if isMissingDependencies {
             throw GenericError.withMessage("Missing one or more dependencies.")
         }
         return providers

--- a/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
@@ -95,15 +95,22 @@ class DependencyGraphExporter {
     private func awaitSerialization(using taskHandleTuples: [(SequenceExecutionHandle<[SerializedProvider]>, String)], withTimeout timeout: TimeInterval) throws -> [SerializedProvider] {
         // Wait for all the generation to complete so we can write all the output into a single file
         var providers = [SerializedProvider]()
+        var missingDependencies = false
         for (taskHandle, componentName) in taskHandleTuples {
             do {
                 let provider = try taskHandle.await(withTimeout: timeout)
                 providers.append(contentsOf: provider)
+            } catch DependencyProviderContentError.missingDependency(let message) {
+                print(message)
+                missingDependencies = true
             } catch SequenceExecutionError.awaitTimeout  {
                 throw GenericError.withMessage("Generating dependency provider for \(componentName) timed out.")
             } catch {
                 throw error
             }
+        }
+        if missingDependencies {
+            throw GenericError.withMessage("Missing one or more dependencies.")
         }
         return providers
     }

--- a/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyGraphExporter.swift
@@ -101,7 +101,7 @@ class DependencyGraphExporter {
                 let provider = try taskHandle.await(withTimeout: timeout)
                 providers.append(contentsOf: provider)
             } catch DependencyProviderContentError.missingDependency(let message) {
-                print(message)
+                warning(message)
                 missingDependencies = true
             } catch SequenceExecutionError.awaitTimeout  {
                 throw GenericError.withMessage("Generating dependency provider for \(componentName) timed out.")

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderContentTask.swift
@@ -18,6 +18,13 @@ import Concurrency
 import Foundation
 import SourceParsingFramework
 
+/// Errors that can occur during dependency checking stage.
+enum DependencyProviderContentError: Error {
+    /// Could not find a dependency along the path to the root.
+    case missingDependency(String)
+}
+
+
 /// The task that walks through the chain of parents for each dependency
 /// item of the dependency protocol that this provider class needs to satisfy.
 class DependencyProviderContentTask: AbstractTask<[ProcessedDependencyProvider]> {
@@ -82,7 +89,7 @@ class DependencyProviderContentTask: AbstractTask<[ProcessedDependencyProvider]>
             if let possibleMatchComponent = possibleMatchComponent {
                 message += " Found possible matches \(possibleMatches) at \(possibleMatchComponent)."
             }
-            throw GenericError.withMessage(message)
+            throw DependencyProviderContentError.missingDependency(message)
         }
 
         return ProcessedDependencyProvider(unprocessed: provider, levelMap: levelMap, processedProperties: properties)

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderContentTask.swift
@@ -144,7 +144,7 @@ class PluginizedDependencyProviderContentTask: AbstractTask<[PluginizedProcessed
             if let possibleMatchComponent = possibleMatchComponent {
                 message += " Found possible matches \(possibleMatches) at \(possibleMatchComponent)."
             }
-            throw GenericError.withMessage(message)
+            throw DependencyProviderContentError.missingDependency(message)
         }
 
         return PluginizedProcessedDependencyProvider(unprocessed: provider, levelMap: levelMap, processedProperties: properties)


### PR DESCRIPTION
- Print all the missing dependencies
- Error at the very end
- This way, uses don't have to error -> add dep -> run needle -> error cycle over and over