### PR TITLE
Switch travis build to Xcode 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.1
+osx_image: xcode10.2
 before_script:
 - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 matrix:


### PR DESCRIPTION
- Too annoying to debug the current (SPM) build failure when the version we're using does not match the remote one.