### PR TITLE
(Sort of) Rollback to Xcode 10.1

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.23.1"),
-        .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.3.0")),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
         .package(url: "https://github.com/uber/swift-common.git", .branch("master")),
     ],
@@ -17,7 +17,7 @@ let package = Package(
         .target(
             name: "NeedleFramework",
             dependencies: [
-                "SPMUtility",
+                "Utility",
                 "SourceKittenFramework",
                 "Concurrency",
                 "SourceParsingFramework",

--- a/Generator/Sources/NeedleFramework/Utilities/Extensions.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/Extensions.swift
@@ -46,3 +46,12 @@ extension Regex {
         return Regex(": *(\(needleModuleName).)?\(protocolName)")
     }
 }
+
+extension Array {
+    /// Create a dictionary with given sequence of elements.
+    public func spm_createDictionary<Key: Hashable, Value>(
+        _ uniqueKeysWithValues: (Element) -> (Key, Value)
+        ) -> [Key: Value] {
+        return Dictionary(uniqueKeysWithValues: self.map(uniqueKeysWithValues))
+    }
+}

--- a/Generator/Sources/needle/GenerateCommand.swift
+++ b/Generator/Sources/needle/GenerateCommand.swift
@@ -18,7 +18,7 @@ import CommandFramework
 import Foundation
 import NeedleFramework
 import SourceParsingFramework
-import SPMUtility
+import Utility
 
 /// The generate command provides the core functionality of needle. It parses
 /// Swift source files by recurively scan the directories starting from the

--- a/Generator/Sources/needle/PrintDependencyTreeCommand.swift
+++ b/Generator/Sources/needle/PrintDependencyTreeCommand.swift
@@ -18,7 +18,7 @@ import CommandFramework
 import Foundation
 import NeedleFramework
 import SourceParsingFramework
-import SPMUtility
+import Utility
 
 /// A command that prints out the static dependency tree starting at RootComponent.
 class PrintDependencyTreeCommand: AbstractCommand {

--- a/Generator/Sources/needle/VersionCommand.swift
+++ b/Generator/Sources/needle/VersionCommand.swift
@@ -17,7 +17,7 @@
 import CommandFramework
 import Foundation
 import NeedleFramework
-import SPMUtility
+import Utility
 
 /// A command that returns the current version of the generator.
 class VersionCommand: AbstractCommand {

--- a/Generator/Sources/needle/main.swift
+++ b/Generator/Sources/needle/main.swift
@@ -19,7 +19,7 @@ import CommandFramework
 import Foundation
 import NeedleFramework
 import SourceParsingFramework
-import SPMUtility
+import Utility
 
 func main() {
     let parser = ArgumentParser(usage: "<subcommand> <options>", overview: "Needle DI code generator.")


### PR DESCRIPTION
- We need Xcode 10.1 to create binaries with the swift libs embedded (CI machines have some 10.14.3 ones)
- SPM is using the master branch of llbuild which is now already on SPM 5.0 spec and is breaking our builds