### PR TITLE
Mark NeedleFoundation as Extension safe

### DIFF
--- a/NeedleFoundation.xcodeproj/project.pbxproj
+++ b/NeedleFoundation.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 		OBJ_39 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -520,6 +521,7 @@
 		OBJ_40 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This is needed to use `NeedleFoundation` in iOS application extensions.