### PR TITLE
Remove static linking of Swift standard libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         - name: "NeedleGeneratorTests"
           script: cd Generator && swift test -Xswiftc -DDEBUG
         - name: "NeedleGeneratorBinary"
-          script: cd Generator && swift build -c release -Xswiftc -static-stdlib
+          script: cd Generator && swift build -c release
         - name: "NeedleSampleMVCApp"
           install: cd Sample/MVC && carthage update --platform ios
           script: xcodebuild build -project ../../Sample/MVC/TicTacToe/TicTacToe.xcodeproj -scheme TicTacToe -destination 'platform=iOS Simulator,OS=12.2,name=iPhone X'

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,6 @@ GENERATOR_VERSION_FOLDER_PATH=$(GENERATOR_FOLDER)/Sources/needle
 GENERATOR_VERSION_FILE_PATH=$(GENERATOR_VERSION_FOLDER_PATH)/Version.swift
 SWIFT_BUILD_FLAGS=--disable-sandbox -c release
 
-# Taken from https://github.com/jpsim/SourceKitten/blob/d90296e473d17d1fecbebacfa9b0476682a02456/Makefile
-UNAME=$(shell uname)
-ifeq ($(UNAME), Darwin)
-USE_SWIFT_STATIC_STDLIB:=$(shell test -d $$(dirname $$(xcrun --find swift))/../lib/swift_static/macosx && echo yes)
-ifeq ($(USE_SWIFT_STATIC_STDLIB), yes)
-SWIFT_BUILD_FLAGS+= -Xswiftc -static-stdlib
-endif
-endif
-
 .PHONY: clean build install uninstall
 
 clean:


### PR DESCRIPTION
- As we've moved to Xcode 10.2, we need to remove the `-static-stdlib` flag