### PR TITLE
Don't add all the extensions imports

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/AbstractDependencyGraphParser.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/AbstractDependencyGraphParser.swift
@@ -121,8 +121,11 @@ class AbstractDependencyGraphParser {
             do {
                 let node = try urlHandle.handle.await(withTimeout: timeout)
                 extensions.append(contentsOf: node.extensions)
-                for statement in node.imports {
-                    imports.insert(statement)
+                // Ignore imports if we don't find anything useful in this file
+                if !node.extensions.isEmpty {
+                    for statement in node.imports {
+                        imports.insert(statement)
+                    }
                 }
             } catch SequenceExecutionError.awaitTimeout(let taskId) {
                 throw DependencyGraphParserError.timeout(urlHandle.fileUrl.absoluteString, taskId)


### PR DESCRIPTION
When we collect imports from source files which contain extensions, we take all the imports regardless of what we find in the file.
Instead, we should collect the import lines only when the file has something useful in it.