### PR TITLE
Add Release Instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,7 @@ Uber welcomes contributions of all kinds and sizes. This includes everything fro
 
 Before we can accept your contributions, we kindly ask you to sign our [Contributor License Agreement](https://cla-assistant.io/uber/needle).
 
-Workflow
---------
+## Workflow
 
 We love GitHub issues!
 
@@ -15,17 +14,15 @@ For big features, please open an issue so that we can agree on the direction, an
 
 Small pull requests for things like typos, bug fixes, etc are always welcome.
 
-DOs and DON'Ts
---------------
+## DOs and DON'Ts
 
-* DO follow our [coding style](https://github.com/raywenderlich/swift-style-guide) 
+* DO follow our [coding style](https://github.com/raywenderlich/swift-style-guide)
 * DO include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken.
 * DO keep the discussions focused. When a new or related topic comes up it's often better to create new issue than to side track the discussion.
 
 * DON'T submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
 
-Guiding Principles
-------------------
+## Guiding Principles
 
 * We allow anyone to participate in our projects. Tasks can be carried out by anyone that demonstrates the capability to complete them
 * Always be respectful of one another. Assume the best in others and act with empathy at all times

--- a/Generator/README.md
+++ b/Generator/README.md
@@ -19,16 +19,10 @@ $ swift build
 Or create an Xcode project and build using the IDE:
 
 ```
-$ swift package generate-xcodeproj --xcconfig-overrides xcode.xcconfig 
+$ swift package generate-xcodeproj --xcconfig-overrides xcode.xcconfig
 ```
 Note: For now, the xcconfig is being used to pass in the DEBUG define.
 
 ### Debugging
 
 Needle is intended to be heavily multi-threaded. This makes stepping through the code rather complicated. To simplify the debugging process, set the `SINGLE_THREADED` enviroment variable for your `Run` configuration in the Scheme Editor to `1` or `YES`.
-
-## Releasing
-
-```
-make publish VERSION_NUMBER
-```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ $ make publish 0.13.0
 
 This runs the steps specified in the `Makefile`.
 
-The `Makefile` does not support failure recovery yet. If a certain step fails, you might want to figure out which step failed, and manually run the remaining steps.
+The `Makefile` does not support failure recovery yet. If a certain step fails, you need to resolve it and manually run the remaining steps.
 
 ## Create a new Github release
-After all steps in the `Makefile` finish successfully, go to the Releases tab and create a new release.
+After all the steps in the `Makefile` finish successfully, go to the Releases tab and create a new release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ $ make publish 0.13.0
 
 This runs the steps specified in the `Makefile`.
 
-The `Makefile` does support failure recovering yet. If a certain step fails, you might want to figure out which step failed, and start manually run the remaining steps.
+The `Makefile` does not support failure recovery yet. If a certain step fails, you might want to figure out which step failed, and manually run the remaining steps.
 
 ## Create a new Github release
 After all steps in the `Makefile` finish successfully, go to the Releases tab and create a new release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+# Publishing a New Release
+*This page contains instructions for admins of this project to release a new version.*
+
+## Run Makefile
+Run `$ make publish VERSION_NUMBER` at the root directory of needle (where the `Makefile` is located)
+
+For example:
+```
+$ make publish 0.13.0
+```
+
+This runs the steps specified in the `Makefile`.
+
+The `Makefile` does support failure recovering yet. If a certain step fails, you might want to figure out which step failed, and start manually run the remaining steps.
+
+## Create a new Github release
+After all steps in the `Makefile` finish successfully, go to the Releases tab and create a new release.


### PR DESCRIPTION
Moving "release instructions" outside of `Generator` directory, into its own document living under project root.