### PR TITLE
Fix generator in Swift 5.2

### DIFF
--- a/Generator/Sources/NeedleFramework/Utilities/ASTUtils.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/ASTUtils.swift
@@ -86,8 +86,11 @@ extension Structure {
                     } else {
                         return propertyItem.property
                     }
+                } else {
+                    // If the accessibility identifier is missing it will be internal or private
+                    // If it's private it will be caught by the compilation step
+                    return propertyItem.property
                 }
-                throw GenericError.withMessage("Property missing accessibility identifier.")
         }
     }
 }


### PR DESCRIPTION
When "key.accessibility" was unknown before Swift 5.2 SouceKit would always return "internal". Some of those cases were "private" before. Now SourceKit don't return the property when it's unknown. To continue with previous behavior we now treat unknown the same as we did before.

Fixes #331.