### PR TITLE
Run tests in Carthage compatible way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ before_script:
 matrix:
     include:
         - name: "NeedleFoundationTests"
-          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTests -destination 'platform=iOS Simulator,OS=13.2.2,name=iPhone 11'
-        - name: "NeedleFoundationTestTests"
-          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundationTestTests -destination 'platform=iOS Simulator,OS=13.2.2,name=iPhone 11'
+          script: xcodebuild test -project NeedleFoundation.xcodeproj -scheme NeedleFoundation -destination 'platform=iOS Simulator,OS=13.2.2,name=iPhone 11'
         - name: "NeedleGeneratorTests"
           script: cd Generator && swift test -Xswiftc -DDEBUG
         - name: "NeedleGeneratorBinary"

--- a/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundation.xcscheme
+++ b/NeedleFoundation.xcodeproj/xcshareddata/xcschemes/NeedleFoundation.xcscheme
@@ -28,9 +28,27 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTests"
+               BuildableName = "NeedleFoundationTests.xctest"
+               BlueprintName = "NeedleFoundationTests"
+               ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NeedleFoundation::NeedleFoundationTestTests"
+               BuildableName = "NeedleFoundationTestTests.xctest"
+               BlueprintName = "NeedleFoundationTestTests"
+               ReferencedContainer = "container:NeedleFoundation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +69,6 @@
             ReferencedContainer = "container:NeedleFoundation.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Now that the shared test-specific schemes are gone we need the `NeedleFoundation` scheme to run its tests.

Fixes the CI failure created by #309.