### PR TITLE
Put back sudo in bash command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode11.4
 before_script:
-- "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash"
+- "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 matrix:
     include:
         - name: "NeedleFoundationTests"


### PR DESCRIPTION
- We have this `sudo` in al our other travis config scripts
- Not sure it actually fixed anything when I removed it in my last commit