### PR TITLE
Fix building NeedleFoundationTest target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             exclude: []),
         .target(
             name: "NeedleFoundationTest",
-            dependencies: []),
+            dependencies: ["NeedleFoundation"]),
         .testTarget(
             name: "NeedleFoundationTestTests",
             dependencies: ["NeedleFoundationTest"],


### PR DESCRIPTION
In the case of your app tests target depends on `NeedleFoundationTest` library and you try to build this target, then it fails with the following error:
<img width="360" alt="Screenshot" src="https://user-images.githubusercontent.com/6864532/86515827-88b6c180-be24-11ea-95dc-dfcbbfde91f8.png">
