### PR TITLE
Mark `needleDependenciesHash` as unused for SwiftLint

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
@@ -59,7 +59,8 @@ class OutputSerializer: Serializer {
 
         \(importsJoined)
         
-        let needleDependenciesHash : String? = \(needleDependenciesHash)
+        // swiftlint:disable unused_declaration
+        private let needleDependenciesHash : String? = \(needleDependenciesHash)
 
         // MARK: - Registration
 

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
@@ -40,7 +40,7 @@ class PluginizedDependencyGraphExporterTests: AbstractPluginizedGeneratorTests {
         XCTAssertTrue(generated!.contains("import UIKit"))
         XCTAssertTrue(generated!.contains("import ScoreSheet"))
         XCTAssertTrue(generated!.contains("import TicTacToeIntegrations"))
-        XCTAssertTrue(generated!.contains("let needleDependenciesHash : String? = \"f7e65514498ad4f99ae8eb589dd36bbc\""))
+        XCTAssertTrue(generated!.contains("private let needleDependenciesHash : String? = \"f7e65514498ad4f99ae8eb589dd36bbc\""))
         XCTAssertTrue(generated!.contains("// MARK: - Registration"))
         XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in\n        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)\n    }"))
         XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in\n        return EmptyDependencyProvider(component: component)\n    }"))


### PR DESCRIPTION
`needleDependenciesHash` is only used to cause a recompile, it's not actually used anywhere. Because of this, it needs the `// swiftlint:disable unused_declaration` comment to prevent SwiftLint from complaining about unused code.

I also made `needleDependenciesHash` private, since it's not used anywhere.