### PR TITLE
Fix SPM build for NeedleFoundationTest target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             exclude: []),
         .target(
             name: "NeedleFoundationTest",
-            dependencies: []),
+            dependencies: ["NeedleFoundation"]),
         .testTarget(
             name: "NeedleFoundationTestTests",
             dependencies: ["NeedleFoundationTest"],


### PR DESCRIPTION
Fixes SPM dependency for NeedleFoundationTest target to resolve build error for the users who depends on this target.