### PR TITLE
Reduce volume of generated code (#337)

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
@@ -34,28 +34,60 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
     ///
     /// - returns: The list of `SerializedProvider`.
     override func execute() -> [SerializedProvider] {
-        return providers.map { (provider: ProcessedDependencyProvider) in
-            return serialize(provider)
+        var result = [SerializedProvider]()
+        // Group the providers based on where the properties are coming from
+        // This will allow us to extract common code for multiple depndency providers
+        // into common base classes
+        var counts = [[ProcessedProperty]: [ProcessedDependencyProvider]]()
+        for provider in providers {
+            let properties = provider.processedProperties
+            counts[properties, default: []].append(provider)
         }
+        let countValues = counts.values.sorted(by: { (left, right) in
+            guard let leftProvider = left.first, let rightProvider = right.first else {
+                fatalError("Dictionary not expected to contain empty arrays")
+            }
+            return leftProvider.unprocessed.pathString < rightProvider.unprocessed.pathString
+        })
+        for matchingProviders in countValues {
+            result.append(contentsOf: serialize(matchingProviders))
+        }
+        return result
     }
 
     // MARK: - Private
 
     private let providers: [ProcessedDependencyProvider]
 
-    private func serialize(_ provider: ProcessedDependencyProvider) -> SerializedProvider {
-        let content = serializedContent(for: provider)
-        let registration = DependencyProviderRegistrationSerializer(provider: provider).serialize()
-        return SerializedProvider(content: content, registration: registration)
+    private func serialize(_ providers: [ProcessedDependencyProvider]) -> [SerializedProvider] {
+        var result = [SerializedProvider]()
+        let (baseClass, content) = serializedBase(for: providers.first!)
+        if providers.first?.isEmptyDependency == false {
+            result.append(SerializedProvider(content: content, registration: ""))
+        }
+        for provider in providers {
+            let content = provider.isEmptyDependency ? "" : serializedContent(for: provider, baseClassSerializer: baseClass)
+            let registration = DependencyProviderRegistrationSerializer(provider: provider).serialize()
+            result.append(SerializedProvider(content: content, registration: registration))
+        }
+        return result
     }
 
-    private func serializedContent(for provider: ProcessedDependencyProvider) -> String {
+    private func serializedContent(for provider: ProcessedDependencyProvider, baseClassSerializer: Serializer) -> String {
         let classNameSerializer = DependencyProviderClassNameSerializer(provider: provider)
-        let propertiesSerializer = PropertiesSerializer(processedProperties: provider.processedProperties)
-        let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: provider.levelMap.keys.sorted())
         let initBodySerializer = DependencyProviderInitBodySerializer(provider: provider)
 
-        let serializer = DependencyProviderSerializer(provider: provider, classNameSerializer: classNameSerializer, propertiesSerializer: propertiesSerializer, sourceComponentsSerializer: sourceComponentsSerializer, initBodySerializer: initBodySerializer)
+        let serializer = DependencyProviderSerializer(provider: provider, classNameSerializer: classNameSerializer, baseClassSerializer: baseClassSerializer, initBodySerializer: initBodySerializer)
         return serializer.serialize()
+    }
+
+    private func serializedBase(for provider: ProcessedDependencyProvider) -> (Serializer, String) {
+        let classNameSerializer = DependencyProviderBaseClassNameSerializer(provider: provider)
+        let propertiesSerializer = PropertiesSerializer(processedProperties: provider.processedProperties)
+        let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: provider.levelMap.keys.sorted())
+        let initBodySerializer = DependencyProviderBaseInitSerializer(provider: provider)
+
+        let serializer = DependencyProviderBaseSerializer(provider: provider, classNameSerializer: classNameSerializer, propertiesSerializer: propertiesSerializer, sourceComponentsSerializer: sourceComponentsSerializer, initBodySerializer: initBodySerializer)
+        return (classNameSerializer, serializer.serialize())
     }
 }

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
@@ -35,28 +35,54 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
     ///
     /// - returns: The list of `SerializedProvider`.
     override func execute() -> [SerializedProvider] {
-        return providers.map { (provider: PluginizedProcessedDependencyProvider) in
-            return serialize(provider)
+        var result = [SerializedProvider]()
+        // Group the providers based on where the properties are coming from
+        // This will allow us to extract common code for multiple depndency providers
+        // into common base classes
+        var counts = [[PluginizedProcessedProperty]: [PluginizedProcessedDependencyProvider]]()
+        for provider in providers {
+            let properties = provider.processedProperties
+            counts[properties, default: []].append(provider)
         }
+        for (baseCount, (_, matchingProviders)) in counts.enumerated() {
+            result.append(contentsOf: serialize(matchingProviders, baseCounter: baseCount))
+        }
+        return result
     }
 
     // MARK: - Private
 
     private let providers: [PluginizedProcessedDependencyProvider]
 
-    private func serialize(_ provider: PluginizedProcessedDependencyProvider) -> SerializedProvider {
-        let content = serializedContent(for: provider)
-        let registration = DependencyProviderRegistrationSerializer(provider: provider.data).serialize()
-        return SerializedProvider(content: content, registration: registration)
+    private func serialize(_ providers: [PluginizedProcessedDependencyProvider], baseCounter: Int) -> [SerializedProvider] {
+        var result = [SerializedProvider]()
+        let (baseClass, content) = serializedBase(for: providers.first!, counter: baseCounter)
+        if providers.first?.data.isEmptyDependency == false {
+            result.append(SerializedProvider(content: content, registration: ""))
+        }
+        for (_, provider) in providers.enumerated() {
+            let content = provider.data.isEmptyDependency ? "" : serializedContent(for: provider, baseClassSerializer: baseClass)
+            let registration = DependencyProviderRegistrationSerializer(provider: provider.data).serialize()
+            result.append(SerializedProvider(content: content, registration: registration))
+        }
+        return result
     }
 
-    private func serializedContent(for provider: PluginizedProcessedDependencyProvider) -> String {
+    private func serializedContent(for provider: PluginizedProcessedDependencyProvider, baseClassSerializer: Serializer) -> String {
         let classNameSerializer = DependencyProviderClassNameSerializer(provider: provider.data)
-        let propertiesSerializer = PluginizedPropertiesSerializer(provider: provider)
-        let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: provider.data.levelMap.keys.sorted())
         let initBodySerializer = DependencyProviderInitBodySerializer(provider: provider.data)
 
-        let serializer = DependencyProviderSerializer(provider: provider.data, classNameSerializer: classNameSerializer, propertiesSerializer: propertiesSerializer, sourceComponentsSerializer: sourceComponentsSerializer, initBodySerializer: initBodySerializer)
+        let serializer = DependencyProviderSerializer(provider: provider.data, classNameSerializer: classNameSerializer, baseClassSerializer: baseClassSerializer, initBodySerializer: initBodySerializer)
         return serializer.serialize()
+    }
+
+    private func serializedBase(for provider: PluginizedProcessedDependencyProvider, counter: Int) -> (Serializer, String) {
+        let classNameSerializer = DependencyProviderBaseClassNameSerializer(provider: provider.data)
+        let propertiesSerializer = PluginizedPropertiesSerializer(provider: provider)
+        let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: provider.data.levelMap.keys.sorted())
+        let initBodySerializer = DependencyProviderBaseInitSerializer(provider: provider.data)
+
+        let serializer = DependencyProviderBaseSerializer(provider: provider.data, classNameSerializer: classNameSerializer, propertiesSerializer: propertiesSerializer, sourceComponentsSerializer: sourceComponentsSerializer, initBodySerializer: initBodySerializer)
+        return (classNameSerializer, serializer.serialize())
     }
 }

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderBaseSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderBaseSerializer.swift
@@ -1,0 +1,67 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A serializer that produces the source code for the entire dependency
+/// provider.
+final class DependencyProviderBaseSerializer: Serializer {
+
+    /// Initializer.
+    ///
+    /// - parameter provider: The provider to generate code for.
+    /// - parameter classNameSerializer: The serializer that produces
+    /// class name.
+    /// - parameter propertiesSerializer: The serializer that produces
+    /// dependency properties.
+    /// - parameter sourceComponentsSerializer: The serializer that produces
+    /// source component properties.
+    /// - parameter initBodySerializer: The serializer that produces
+    /// the body of the initializer.
+    init(provider: ProcessedDependencyProvider, classNameSerializer: Serializer, propertiesSerializer: Serializer, sourceComponentsSerializer: Serializer, initBodySerializer: Serializer) {
+        self.provider = provider
+        self.classNameSerializer = classNameSerializer
+        self.propertiesSerializer = propertiesSerializer
+        self.sourceComponentsSerializer = sourceComponentsSerializer
+        self.initBodySerializer = initBodySerializer
+    }
+
+    /// Serialize the data model and produce the entire dependency provider
+    /// source code.
+    ///
+    /// - returns: The entire source code for the dependency provider.
+    func serialize() -> String {
+        guard !provider.isEmptyDependency else {
+            return ""
+        }
+
+        return """
+        private class \(classNameSerializer.serialize()): \(provider.unprocessed.dependency.name) {
+        \(propertiesSerializer.serialize())
+        \(sourceComponentsSerializer.serialize())
+        \(initBodySerializer.serialize())
+        }\n
+        """
+    }
+
+    // MARK: - Private
+
+    private let provider: ProcessedDependencyProvider
+    private let classNameSerializer: Serializer
+    private let propertiesSerializer: Serializer
+    private let sourceComponentsSerializer: Serializer
+    private let initBodySerializer: Serializer
+}

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderClassNameSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderClassNameSerializer.swift
@@ -38,3 +38,27 @@ class DependencyProviderClassNameSerializer: Serializer {
 
     private let provider: ProcessedDependencyProvider
 }
+
+/// A serializer that produces the class name for the dependency provider base class.
+final class DependencyProviderBaseClassNameSerializer: Serializer {
+
+    /// Initializer.
+    ///
+    /// - parameter provider: The provider to generate class name for.
+    /// - parameter counter: When making multiple instances, use a unique value here.
+    init(provider: ProcessedDependencyProvider) {
+        self.provider = provider
+    }
+
+    /// Serialize the data model and produce the class name code.
+    ///
+    /// - returns: The class name code.
+    func serialize() -> String {
+        let pathId = String(provider.unprocessed.pathString.shortSHA256Value)
+        return "\(provider.unprocessed.dependency.name)\(pathId)BaseProvider"
+    }
+
+    // MARK: - Private
+
+    private let provider: ProcessedDependencyProvider
+}

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderInitBodySerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderInitBodySerializer.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A serializer that produces the initializer body code for the dependency
 /// provider.
-class DependencyProviderInitBodySerializer: Serializer {
+final class DependencyProviderInitBodySerializer: Serializer {
 
     /// Initializer.
     ///
@@ -35,9 +35,49 @@ class DependencyProviderInitBodySerializer: Serializer {
         return provider.levelMap
             .sorted(by: { $0.key < $1.key })
             .map { (componentType: String, level: Int) in
-            return "        \(componentType.lowercasedFirstChar()) = component\(String(repeating: ".parent", count: level)) as! \(componentType)"
+                return "\(componentType.lowercasedFirstChar()): component\(String(repeating: ".parent", count: level)) as! \(componentType)"
+        }
+        .joined(separator: ", ")
+    }
+
+    // MARK: - Private
+
+    private let provider: ProcessedDependencyProvider
+}
+
+/// A serializer that produces the initializer body code for the dependency
+/// provider.
+class DependencyProviderBaseInitSerializer: Serializer {
+
+    /// Initializer.
+    ///
+    /// - parameter provider: The provider to generate initializer body
+    /// source code for.
+    init(provider: ProcessedDependencyProvider) {
+        self.provider = provider
+    }
+
+    /// Serialize the data model and produce the initializer body code.
+    ///
+    /// - returns: The initializer body source code.
+    func serialize() -> String {
+        let arguments = provider.levelMap
+            .sorted(by: { $0.key < $1.key })
+            .map { (componentType: String, level: Int) in
+                return "\(componentType.lowercasedFirstChar()): \(componentType)"
+        }
+        .joined(separator: ", ")
+        let body = provider.levelMap
+            .sorted(by: { $0.key < $1.key })
+            .map { (componentType: String, level: Int) in
+            return "        self.\(componentType.lowercasedFirstChar()) = \(componentType.lowercasedFirstChar())"
         }
         .joined(separator: "\n")
+        return """
+    init(\(arguments)) {
+\(body)
+    }
+"""
     }
 
     // MARK: - Private

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderSerializer.swift
@@ -16,27 +16,16 @@
 
 import Foundation
 
-/// A serializer that produces the source code for the entire dependency
-/// provider.
+/// A serializer that produces the source code for the dependency
+/// provider. It's mostly empty as the core logic lives in the
+/// superclass
 class DependencyProviderSerializer: Serializer {
 
-    /// Initializer.
-    ///
-    /// - parameter provider: The provider to generate code for.
-    /// - parameter classNameSerializer: The serializer that produces
-    /// class name.
-    /// - parameter propertiesSerializer: The serializer that produces
-    /// dependency properties.
-    /// - parameter sourceComponentsSerializer: The serializer that produces
-    /// source component properties.
-    /// - parameter initBodySerializer: The serializer that produces
-    /// the body of the initializer.
-    init(provider: ProcessedDependencyProvider, classNameSerializer: Serializer, propertiesSerializer: Serializer, sourceComponentsSerializer: Serializer, initBodySerializer: Serializer) {
-        self.provider = provider
+    init(provider: ProcessedDependencyProvider, classNameSerializer: Serializer, baseClassSerializer: Serializer, initBodySerializer: Serializer) {
         self.classNameSerializer = classNameSerializer
-        self.propertiesSerializer = propertiesSerializer
-        self.sourceComponentsSerializer = sourceComponentsSerializer
+        self.baseClassSerializer = baseClassSerializer
         self.initBodySerializer = initBodySerializer
+        self.provider = provider
     }
 
     /// Serialize the data model and produce the entire dependency provider
@@ -44,27 +33,20 @@ class DependencyProviderSerializer: Serializer {
     ///
     /// - returns: The entire source code for the dependency provider.
     func serialize() -> String {
-        guard !provider.isEmptyDependency else {
-            return ""
-        }
-
         return """
-        /// \(provider.unprocessed.pathString)
-        private class \(classNameSerializer.serialize()): \(provider.unprocessed.dependency.name) {
-        \(propertiesSerializer.serialize())
-        \(sourceComponentsSerializer.serialize())
-            init(component: NeedleFoundation.Scope) {
-        \(initBodySerializer.serialize())
-            }
-        }\n
-        """
+/// \(provider.unprocessed.pathString)
+private class \(classNameSerializer.serialize()): \(baseClassSerializer.serialize()) {
+    init(component: NeedleFoundation.Scope) {
+        super.init(\(initBodySerializer.serialize()))
+    }
+}\n
+"""
     }
 
     // MARK: - Private
 
     private let provider: ProcessedDependencyProvider
     private let classNameSerializer: Serializer
-    private let propertiesSerializer: Serializer
-    private let sourceComponentsSerializer: Serializer
+    private let baseClassSerializer: Serializer
     private let initBodySerializer: Serializer
 }

--- a/Generator/Sources/NeedleFramework/Models/Pluginized/PluginizedProperty.swift
+++ b/Generator/Sources/NeedleFramework/Models/Pluginized/PluginizedProperty.swift
@@ -29,7 +29,7 @@ enum AuxillarySourceType {
 
 /// An extended data model representing a single dependency property that
 /// has gone through generation processing.
-struct PluginizedProcessedProperty {
+struct PluginizedProcessedProperty: Equatable, Hashable {
     /// The actual data of this dependency property.
     let data: ProcessedProperty
     /// If the property was found in the auxillary scope, this tells us the

--- a/Generator/Sources/NeedleFramework/Models/Property.swift
+++ b/Generator/Sources/NeedleFramework/Models/Property.swift
@@ -27,7 +27,7 @@ struct Property: Hashable {
 
 /// A data model representing a single dependency property that has gone through
 /// generation processing.
-struct ProcessedProperty: Equatable {
+struct ProcessedProperty: Equatable, Hashable {
     /// The unprocessed property we started with.
     let unprocessed: Property
     /// Type of the Component where this property is satisfied.

--- a/Generator/Tests/NeedleFrameworkTests/Generating/DependencyGraphExporterTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/DependencyGraphExporterTests.swift
@@ -40,16 +40,70 @@ class DependencyGraphExporterTests: AbstractGeneratorTests {
         XCTAssertTrue(generated!.contains("import RxSwift"))
         XCTAssertTrue(generated!.contains("import UIKit"))
         XCTAssertTrue(generated!.contains("// MARK: - Registration"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent\") { component in\n        return GameDependency1ab5926a977f706d3195Provider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent\") { component in\n        return ScoreSheetDependency97f2595a691a56781aaaProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->ScoreSheetComponent\") { component in\n        return ScoreSheetDependencycbd7fa4bae2ee69a1926Provider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in\n        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in\n        return EmptyDependencyProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in\n        return EmptyDependencyProvider(component: component)\n    }"))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent\") { component in
+        return GameDependency1ab5926a977f706d3195Provider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent\") { component in
+        return ScoreSheetDependency97f2595a691a56781aaaProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->ScoreSheetComponent\") { component in
+        return ScoreSheetDependencycbd7fa4bae2ee69a1926Provider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in
+        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in
+        return EmptyDependencyProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in
+        return EmptyDependencyProvider(component: component)
+    }
+"""))
         XCTAssertTrue(generated!.contains("// MARK: - Providers"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedInComponent->GameComponent\nprivate class GameDependency1ab5926a977f706d3195Provider: GameDependency {\n    var mutableScoreStream: MutableScoreStream {\n        return loggedInComponent.mutableScoreStream\n    }\n    var playersStream: PlayersStream {\n        return rootComponent.playersStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    private let rootComponent: RootComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent as! LoggedInComponent\n        rootComponent = component.parent.parent as! RootComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent\nprivate class ScoreSheetDependency97f2595a691a56781aaaProvider: ScoreSheetDependency {\n    var scoreStream: ScoreStream {\n        return loggedInComponent.scoreStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent.parent as! LoggedInComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedInComponent->ScoreSheetComponent\nprivate class ScoreSheetDependencycbd7fa4bae2ee69a1926Provider: ScoreSheetDependency {\n    var scoreStream: ScoreStream {\n        return loggedInComponent.scoreStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent as! LoggedInComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedOutComponent\nprivate class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependency {\n    var mutablePlayersStream: MutablePlayersStream {\n        return rootComponent.mutablePlayersStream\n    }\n    private let rootComponent: RootComponent\n    init(component: NeedleFoundation.Scope) {\n        rootComponent = component.parent as! RootComponent\n    }\n}"))
+        XCTAssertTrue(generated!.contains("""
+private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
+    var mutableScoreStream: MutableScoreStream {
+        return loggedInComponent.mutableScoreStream
+    }
+    var playersStream: PlayersStream {
+        return rootComponent.playersStream
+    }
+    private let loggedInComponent: LoggedInComponent
+    private let rootComponent: RootComponent
+"""))
+        XCTAssertTrue(generated!.contains("""
+private class ScoreSheetDependency97f2595a691a56781aaaBaseProvider: ScoreSheetDependency {
+    var scoreStream: ScoreStream {
+        return loggedInComponent.scoreStream
+    }
+    private let loggedInComponent: LoggedInComponent
+"""))
+        XCTAssertTrue(generated!.contains("""
+/// ^->RootComponent->LoggedInComponent->ScoreSheetComponent
+private class ScoreSheetDependencycbd7fa4bae2ee69a1926Provider: ScoreSheetDependency97f2595a691a56781aaaBaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(loggedInComponent: component.parent as! LoggedInComponent)
+    }
+}
+"""))
+        XCTAssertTrue(generated!.contains("""
+/// ^->RootComponent->LoggedOutComponent
+private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependencyacada53ea78d270efa2fBaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(rootComponent: component.parent as! RootComponent)
+    }
+}
+"""))
     }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderSerializerTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderSerializerTaskTests.swift
@@ -28,32 +28,94 @@ class DependencyProviderSerializerTaskTests: AbstractGeneratorTests {
             let processedProviders = try! DependencyProviderContentTask(providers: providers).execute()
             for provider in processedProviders {
                 let serializedProviders = DependencyProviderSerializerTask(providers: [provider]).execute()
-                XCTAssertEqual(serializedProviders.count, 1)
-                verify(provider, against: serializedProviders[0])
+                XCTAssert(serializedProviders.count > 0 && serializedProviders.count < 3)
+                verify(provider, against: serializedProviders)
             }
         }
 
         XCTAssertEqual(imports, ["import NeedleFoundation", "import RxSwift", "import UIKit"])
     }
 
-    private func verify(_ provider: ProcessedDependencyProvider, against serializedProvider: SerializedProvider) {
+    private func verify(_ provider: ProcessedDependencyProvider, against serializedProviders: [SerializedProvider]) {
         switch provider.unprocessed.pathString {
         case "^->RootComponent->LoggedInComponent->GameComponent":
-            XCTAssertEqual(serializedProvider.registration, "__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent\") { component in\n    return GameDependency1ab5926a977f706d3195Provider(component: component)\n}\n")
-            XCTAssertEqual(serializedProvider.content, "/// ^->RootComponent->LoggedInComponent->GameComponent\nprivate class GameDependency1ab5926a977f706d3195Provider: GameDependency {\n    var mutableScoreStream: MutableScoreStream {\n        return loggedInComponent.mutableScoreStream\n    }\n    var playersStream: PlayersStream {\n        return rootComponent.playersStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    private let rootComponent: RootComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent as! LoggedInComponent\n        rootComponent = component.parent.parent as! RootComponent\n    }\n}\n")
+            XCTAssertEqual(serializedProviders[1].registration, """
+__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent") { component in
+    return GameDependency1ab5926a977f706d3195Provider(component: component)
+}
+
+""")
+            XCTAssertEqual(serializedProviders[1].content, """
+/// ^->RootComponent->LoggedInComponent->GameComponent
+private class GameDependency1ab5926a977f706d3195Provider: GameDependency1ab5926a977f706d3195BaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(loggedInComponent: component.parent as! LoggedInComponent, rootComponent: component.parent.parent as! RootComponent)
+    }
+}
+
+""")
         case "^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent":
-            XCTAssertEqual(serializedProvider.registration, "__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent\") { component in\n    return ScoreSheetDependency97f2595a691a56781aaaProvider(component: component)\n}\n")
-            XCTAssertEqual(serializedProvider.content, "/// ^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent\nprivate class ScoreSheetDependency97f2595a691a56781aaaProvider: ScoreSheetDependency {\n    var scoreStream: ScoreStream {\n        return loggedInComponent.scoreStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent.parent as! LoggedInComponent\n    }\n}\n")
+            XCTAssertEqual(serializedProviders[1].registration, """
+__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent\") { component in
+    return ScoreSheetDependency97f2595a691a56781aaaProvider(component: component)
+}
+
+""")
+            XCTAssertEqual(serializedProviders[1].content, """
+/// ^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent
+private class ScoreSheetDependency97f2595a691a56781aaaProvider: ScoreSheetDependency97f2595a691a56781aaaBaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(loggedInComponent: component.parent.parent as! LoggedInComponent)
+    }
+}
+
+""")
         case "^->RootComponent->LoggedInComponent->ScoreSheetComponent":
-            XCTAssertEqual(serializedProvider.registration, "__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->ScoreSheetComponent\") { component in\n    return ScoreSheetDependencycbd7fa4bae2ee69a1926Provider(component: component)\n}\n")
-            XCTAssertEqual(serializedProvider.content, "/// ^->RootComponent->LoggedInComponent->ScoreSheetComponent\nprivate class ScoreSheetDependencycbd7fa4bae2ee69a1926Provider: ScoreSheetDependency {\n    var scoreStream: ScoreStream {\n        return loggedInComponent.scoreStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent as! LoggedInComponent\n    }\n}\n")
+            XCTAssertEqual(serializedProviders[1].registration, """
+__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->ScoreSheetComponent\") { component in
+    return ScoreSheetDependencycbd7fa4bae2ee69a1926Provider(component: component)
+}
+
+""")
+            XCTAssertEqual(serializedProviders[1].content, """
+/// ^->RootComponent->LoggedInComponent->ScoreSheetComponent
+private class ScoreSheetDependencycbd7fa4bae2ee69a1926Provider: ScoreSheetDependencycbd7fa4bae2ee69a1926BaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(loggedInComponent: component.parent as! LoggedInComponent)
+    }
+}
+
+""")
         case "^->RootComponent->LoggedOutComponent":
-            XCTAssertEqual(serializedProvider.registration, "__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in\n    return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)\n}\n")
-            XCTAssertEqual(serializedProvider.content, "/// ^->RootComponent->LoggedOutComponent\nprivate class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependency {\n    var mutablePlayersStream: MutablePlayersStream {\n        return rootComponent.mutablePlayersStream\n    }\n    private let rootComponent: RootComponent\n    init(component: NeedleFoundation.Scope) {\n        rootComponent = component.parent as! RootComponent\n    }\n}\n")
+            XCTAssertEqual(serializedProviders[1].registration, """
+__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in
+    return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)
+}
+
+""")
+            XCTAssertEqual(serializedProviders[1].content, """
+/// ^->RootComponent->LoggedOutComponent
+private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependencyacada53ea78d270efa2fBaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(rootComponent: component.parent as! RootComponent)
+    }
+}
+
+""")
         case "^->RootComponent->LoggedInComponent":
-            XCTAssertEqual(serializedProvider.registration, "__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in\n    return EmptyDependencyProvider(component: component)\n}\n")
+            XCTAssertEqual(serializedProviders[0].registration, """
+__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in
+    return EmptyDependencyProvider(component: component)
+}
+
+""")
         case "^->RootComponent":
-            XCTAssertEqual(serializedProvider.registration, "__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in\n    return EmptyDependencyProvider(component: component)\n}\n")
+            XCTAssertEqual(serializedProviders[0].registration, """
+__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in
+    return EmptyDependencyProvider(component: component)
+}
+
+""")
         default:
             XCTFail("Unverified provider with path \(provider.unprocessed.pathString)")
         }

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
@@ -42,22 +42,158 @@ class PluginizedDependencyGraphExporterTests: AbstractPluginizedGeneratorTests {
         XCTAssertTrue(generated!.contains("import TicTacToeIntegrations"))
         XCTAssertTrue(generated!.contains("private let needleDependenciesHash : String? = \"f7e65514498ad4f99ae8eb589dd36bbc\""))
         XCTAssertTrue(generated!.contains("// MARK: - Registration"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in\n        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in\n        return EmptyDependencyProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent\") { component in\n        return ScoreSheetDependencyea879b8e06763171478bProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent\") { component in\n        return ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent\") { component in\n        return EmptyDependencyProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent\") { component in\n        return EmptyDependencyProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent\") { component in\n        return GameDependency1ab5926a977f706d3195Provider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in\n        return EmptyDependencyProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: \"GameComponent\") { component in\n        return GamePluginExtensionProvider(component: component)\n    }"))
-        XCTAssertTrue(generated!.contains("__PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: \"LoggedInComponent\") { component in\n        return LoggedInPluginExtensionProvider(component: component)\n    }"))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in
+        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in
+        return EmptyDependencyProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent\") { component in
+        return ScoreSheetDependencyea879b8e06763171478bProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent\") { component in
+        return ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent\") { component in
+        return EmptyDependencyProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent\") { component in
+        return EmptyDependencyProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent\") { component in
+        return GameDependency1ab5926a977f706d3195Provider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in
+        return EmptyDependencyProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: \"GameComponent\") { component in
+        return GamePluginExtensionProvider(component: component)
+    }
+"""))
+        XCTAssertTrue(generated!.contains("""
+    __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: \"LoggedInComponent\") { component in
+        return LoggedInPluginExtensionProvider(component: component)
+    }
+"""))
         XCTAssertTrue(generated!.contains("// MARK: - Providers"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedOutComponent\nprivate class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependency {\n    var mutablePlayersStream: MutablePlayersStream {\n        return rootComponent.mutablePlayersStream\n    }\n    private let rootComponent: RootComponent\n    init(component: NeedleFoundation.Scope) {\n        rootComponent = component.parent as! RootComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent\nprivate class ScoreSheetDependencyea879b8e06763171478bProvider: ScoreSheetDependency {\n    var scoreStream: ScoreStream {\n        return (loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent).scoreStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent.parent.parent as! LoggedInComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent\nprivate class ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider: ScoreSheetDependency {\n    var scoreStream: ScoreStream {\n        return loggedInNonCoreComponent.scoreStream\n    }\n    private let loggedInNonCoreComponent: LoggedInNonCoreComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInNonCoreComponent = component.parent as! LoggedInNonCoreComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// ^->RootComponent->LoggedInComponent->GameComponent\nprivate class GameDependency1ab5926a977f706d3195Provider: GameDependency {\n    var mutableScoreStream: MutableScoreStream {\n        return loggedInComponent.pluginExtension.mutableScoreStream\n    }\n    var playersStream: PlayersStream {\n        return rootComponent.playersStream\n    }\n    private let loggedInComponent: LoggedInComponent\n    private let rootComponent: RootComponent\n    init(component: NeedleFoundation.Scope) {\n        loggedInComponent = component.parent as! LoggedInComponent\n        rootComponent = component.parent.parent as! RootComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// GameComponent plugin extension\nprivate class GamePluginExtensionProvider: GamePluginExtension {\n    var scoreSheetBuilder: ScoreSheetBuilder {\n        return gameNonCoreComponent.scoreSheetBuilder\n    }\n    private unowned let gameNonCoreComponent: GameNonCoreComponent\n    init(component: NeedleFoundation.Scope) {\n        let gameComponent = component as! GameComponent\n        gameNonCoreComponent = gameComponent.nonCoreComponent as! GameNonCoreComponent\n    }\n}"))
-        XCTAssertTrue(generated!.contains("/// LoggedInComponent plugin extension\nprivate class LoggedInPluginExtensionProvider: LoggedInPluginExtension {\n    var scoreSheetBuilder: ScoreSheetBuilder {\n        return loggedInNonCoreComponent.scoreSheetBuilder\n    }\n    var mutableScoreStream: MutableScoreStream {\n        return loggedInNonCoreComponent.mutableScoreStream\n    }\n    private unowned let loggedInNonCoreComponent: LoggedInNonCoreComponent\n    init(component: NeedleFoundation.Scope) {\n        let loggedInComponent = component as! LoggedInComponent\n        loggedInNonCoreComponent = loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent\n    }\n}"))
+        XCTAssertTrue(generated!.contains("""
+private class LoggedOutDependencyacada53ea78d270efa2fBaseProvider: LoggedOutDependency {
+    var mutablePlayersStream: MutablePlayersStream {
+        return rootComponent.mutablePlayersStream
+    }
+    private let rootComponent: RootComponent
+    init(rootComponent: RootComponent) {
+        self.rootComponent = rootComponent
+    }
+}
+/// ^->RootComponent->LoggedOutComponent
+private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependencyacada53ea78d270efa2fBaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(rootComponent: component.parent as! RootComponent)
+    }
+}
+"""))
+        XCTAssertTrue(generated!.contains("""
+private class ScoreSheetDependencyea879b8e06763171478bBaseProvider: ScoreSheetDependency {
+    var scoreStream: ScoreStream {
+        return (loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent).scoreStream
+    }
+    private let loggedInComponent: LoggedInComponent
+    init(loggedInComponent: LoggedInComponent) {
+        self.loggedInComponent = loggedInComponent
+    }
+}
+/// ^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent
+private class ScoreSheetDependencyea879b8e06763171478bProvider: ScoreSheetDependencyea879b8e06763171478bBaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(loggedInComponent: component.parent.parent.parent as! LoggedInComponent)
+    }
+}
+"""))
+        XCTAssertTrue(generated!.contains("""
+private class ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider: ScoreSheetDependency {
+    var scoreStream: ScoreStream {
+        return loggedInNonCoreComponent.scoreStream
+    }
+    private let loggedInNonCoreComponent: LoggedInNonCoreComponent
+    init(loggedInNonCoreComponent: LoggedInNonCoreComponent) {
+        self.loggedInNonCoreComponent = loggedInNonCoreComponent
+    }
+}
+/// ^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent
+private class ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider: ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(loggedInNonCoreComponent: component.parent as! LoggedInNonCoreComponent)
+    }
+}
+"""))
+        XCTAssertTrue(generated!.contains("""
+private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
+    var mutableScoreStream: MutableScoreStream {
+        return loggedInComponent.pluginExtension.mutableScoreStream
+    }
+    var playersStream: PlayersStream {
+        return rootComponent.playersStream
+    }
+    private let loggedInComponent: LoggedInComponent
+    private let rootComponent: RootComponent
+    init(loggedInComponent: LoggedInComponent, rootComponent: RootComponent) {
+        self.loggedInComponent = loggedInComponent
+        self.rootComponent = rootComponent
+    }
+}
+/// ^->RootComponent->LoggedInComponent->GameComponent
+private class GameDependency1ab5926a977f706d3195Provider: GameDependency1ab5926a977f706d3195BaseProvider {
+    init(component: NeedleFoundation.Scope) {
+        super.init(loggedInComponent: component.parent as! LoggedInComponent, rootComponent: component.parent.parent as! RootComponent)
+    }
+}
+"""))
+        XCTAssertTrue(generated!.contains("""
+/// GameComponent plugin extension
+private class GamePluginExtensionProvider: GamePluginExtension {
+    var scoreSheetBuilder: ScoreSheetBuilder {
+        return gameNonCoreComponent.scoreSheetBuilder
+    }
+    private unowned let gameNonCoreComponent: GameNonCoreComponent
+    init(component: NeedleFoundation.Scope) {
+        let gameComponent = component as! GameComponent
+        gameNonCoreComponent = gameComponent.nonCoreComponent as! GameNonCoreComponent
+    }
+}
+"""))
+        XCTAssertTrue(generated!.contains("""
+/// LoggedInComponent plugin extension
+private class LoggedInPluginExtensionProvider: LoggedInPluginExtension {
+    var scoreSheetBuilder: ScoreSheetBuilder {
+        return loggedInNonCoreComponent.scoreSheetBuilder
+    }
+    var mutableScoreStream: MutableScoreStream {
+        return loggedInNonCoreComponent.mutableScoreStream
+    }
+    private unowned let loggedInNonCoreComponent: LoggedInNonCoreComponent
+    init(component: NeedleFoundation.Scope) {
+        let loggedInComponent = component as! LoggedInComponent
+        loggedInNonCoreComponent = loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent
+    }
+}
+"""))
     }
 }


### PR DESCRIPTION
- Use base classes to avoid repetition. We find providers which are all getting items from the same exact scopes
- A base class is generated for these similar scopes and then used by each of the providers
- The number of "hops" to get to the levels varies and is passed in by the subclasses
- Had to update generator tests
- Some tiny fixes to remove Xcode warnings

- Added a sort so that we traverse the dictionary in the same order each run