### PR TITLE
Fix `isComponent` check: should not include "Component" from a generic argument list

### DIFF
--- a/Generator/Sources/NeedleFramework/Utilities/SwiftSyntaxExtensions.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/SwiftSyntaxExtensions.swift
@@ -27,9 +27,13 @@ protocol EntityNode: SyntaxNodeWithModifiers {
 extension EntityNode {
     /// Checks whether the entity inherits from a certain type with `typeName`
     func inherits(from typeName: String) -> Bool {
-        inheritanceClause?.inheritedTypeCollection.first?.typeName.tokens.contains(where: { tokenSyntax -> Bool in
-            tokenSyntax.text == typeName
-        }) == true
+        // Usually, first token is the inherited type name. But sometimes it could also be the module prefix.
+        // In that case, we need to look for the actual type name by skipping two tokens ahead.
+        var inheritanceTypeToken = inheritanceClause?.inheritedTypeCollection.first?.typeName.firstToken
+        if inheritanceTypeToken?.nextToken?.tokenKind == TokenKind.period {
+            inheritanceTypeToken = inheritanceTypeToken?.nextToken?.nextToken
+        }
+        return inheritanceTypeToken?.text == typeName
     }
 }
 

--- a/Generator/Sources/NeedleFramework/Utilities/SwiftSyntaxExtensions.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/SwiftSyntaxExtensions.swift
@@ -27,13 +27,15 @@ protocol EntityNode: SyntaxNodeWithModifiers {
 extension EntityNode {
     /// Checks whether the entity inherits from a certain type with `typeName`
     func inherits(from typeName: String) -> Bool {
+        
+        let inheritedTypeSyntax = inheritanceClause?.inheritedTypeCollection.first?.typeName
         // Usually, first token is the inherited type name. But sometimes it could also be the module prefix.
-        // In that case, we need to look for the actual type name by skipping two tokens ahead.
-        var inheritanceTypeToken = inheritanceClause?.inheritedTypeCollection.first?.typeName.firstToken
-        if inheritanceTypeToken?.nextToken?.tokenKind == TokenKind.period {
-            inheritanceTypeToken = inheritanceTypeToken?.nextToken?.nextToken
+        // In that case, we need to look for the actual type name by checking for `MemberTypeIdentifierSyntax`
+        if inheritedTypeSyntax?.firstToken?.nextToken?.tokenKind != TokenKind.period {
+            return inheritedTypeSyntax?.firstToken?.text == typeName
+        } else {
+            return inheritedTypeSyntax?.as(MemberTypeIdentifierSyntax.self)?.name.text == typeName
         }
-        return inheritanceTypeToken?.text == typeName
     }
 }
 

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -102,6 +102,12 @@ BExtension,    SomeNonCoreComponent
     }
 }
 
+class SimpleComponentizedBuilder: ComponentizedBuilder<Component, Dependency, (), ()> {
+}
+
+class SimpleComponentizedBuilderTwo: NeedleFoundation.ComponentizedBuilder<Component, Dependency, (), ()> {
+}
+
 protocol My2Dependency: NeedleFoundation.Dependency {
     var backPack: Pack { get }
     var maybeMoney: Dollar? { get }

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -102,11 +102,11 @@ BExtension,    SomeNonCoreComponent
     }
 }
 
-class SimpleComponentizedBuilder: ComponentizedBuilder<Component, Dependency, (), ()> {
-}
+class SimpleComponentizedBuilder: ComponentizedBuilder<Component, Dependency, (), ()> {}
 
-class SimpleComponentizedBuilderTwo: NeedleFoundation.ComponentizedBuilder<Component, Dependency, (), ()> {
-}
+class SimpleComponentizedBuilderTwo: NeedleFoundation.ComponentizedBuilder<Component, Dependency, (), ()> {}
+
+class NestedNonComponent: NeedleFoundation.Component.NonComponent<Component, Dependency> {}
 
 protocol My2Dependency: NeedleFoundation.Dependency {
     var backPack: Pack { get }


### PR DESCRIPTION
After migrating to SwiftSyntax, `class SimpleComponentizedBuilder: ComponentizedBuilder<Component, Dependency, (), ()>` was incorrectly being considered a component, because the inheritance clause's `Component` generic argument was thought to be the parent class.

I fixed that, added unit test cases, and comments to the not-so-intuitive implementation (mainly to account for `NeedleFoundation.Component`).