### PR TITLE
[Bug fix] Make sure the full import statement is captured

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/BaseVisitor.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/BaseVisitor.swift
@@ -59,10 +59,7 @@ class BaseVisitor: SyntaxVisitor {
     }
     
     override func visitPost(_ node: ImportDeclSyntax) {
-        let importStatement = node.importTok.text + " " +
-            node.path
-                .map { $0.name.text }
-                .joined(separator: ".")
+        let importStatement = node.withoutTrivia().description.trimmed
         imports.append(importStatement)
     }
     

--- a/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Fixtures/ComponentSample.swift
@@ -1,5 +1,6 @@
 import UIKit
 import RIBs;    import Foundation
+import protocol Audio.Recordable
 
 protocol MyDependency: Dependency {
     var candy: Candy { get }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DeclarationsParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DeclarationsParserTaskTests.swift
@@ -40,7 +40,7 @@ class DeclarationsParserTaskTests: AbstractParserTests {
     func test_execute_withValidAndInvalidComponentsDependencies_verifyDependencyGraphNode() {
         let sourceUrl = fixtureUrl(for: "ComponentSample.swift")
         let sourceContent = try! String(contentsOf: sourceUrl)
-        let imports = ["import UIKit", "import RIBs", "import Foundation"]
+        let imports = ["import UIKit", "import RIBs", "import Foundation", "import protocol Audio.Recordable"]
         let ast = AST(sourceHash: MD5(string: sourceContent),
                       sourceFileSyntax: try! SyntaxParser.parse(sourceUrl))
         
@@ -141,6 +141,6 @@ class DeclarationsParserTaskTests: AbstractParserTests {
         XCTAssertEqual(myRComp.properties, [Property(name: "rootObj", type: "Obj")])
 
         // Imports.
-        XCTAssertEqual(node.imports, ["import UIKit", "import RIBs", "import Foundation"])
+        XCTAssertEqual(node.imports, ["import UIKit", "import RIBs", "import Foundation", "import protocol Audio.Recordable"])
     }
 }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DependencyGraphParserTests.swift
@@ -67,7 +67,7 @@ class DependencyGraphParserTests: AbstractParserTests {
             let parentComponent = components.filter { $0.name == "MyComponent" }.first!
             XCTAssertTrue(childComponent.parents.first! == parentComponent)
             XCTAssertEqual(components.count, 12)
-            XCTAssertEqual(imports, ["import Foundation", "import RIBs", "import RxSwift", "import UIKit", "import Utility"])
+            XCTAssertEqual(imports, ["import Foundation", "import RIBs", "import RxSwift", "import UIKit", "import Utility", "import protocol Audio.Recordable"])
         } catch {
             XCTFail("\(error)")
         }

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDependencyGraphParserTests.swift
@@ -68,7 +68,7 @@ class PluginizedDependencyGraphParserTests: AbstractPluginizedParserTests {
             XCTAssertTrue(childComponent.parents.first! == parentComponent)
             XCTAssertEqual(components.count, 16)
             XCTAssertEqual(pluginizedComponents.count, 3)
-            XCTAssertEqual(imports, ["import Foundation", "import NeedleFoundation", "import RIBs", "import RxSwift", "import ScoreSheet", "import UIKit", "import Utility"])
+            XCTAssertEqual(imports, ["import Foundation", "import NeedleFoundation", "import RIBs", "import RxSwift", "import ScoreSheet", "import UIKit", "import Utility", "import protocol Audio.Recordable"])
         } catch {
             XCTFail("\(error)")
         }


### PR DESCRIPTION
The existing implementation missed the `protocol` keyword in an import statement like `import protocol Foo.Bar`.
Updated unit tests to include the failure case.