### PR TITLE
Separate "release" and "publish" as two commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ release:
 
 publish:
 	brew update && brew bump-formula-pr --tag=$(NEW_VERSION_TAG) --revision=$(shell git rev-parse HEAD) needle
-	pod trunk push
+	pod trunk push --allow-warnings
 
 archive_generator: clean build
 	mv $(GENERATOR_ARCHIVE_PATH) $(GENERATOR_FOLDER)/bin/

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ uninstall:
 	rm -f "$(BINARY_FOLDER)/needle"
 	rm -f "/usr/local/bin/needle"
 
-publish:
+release:
 	git checkout master
 	$(eval NEW_VERSION := $(filter-out $@, $(MAKECMDGOALS)))
 	@sed 's/__VERSION_NUMBER__/$(NEW_VERSION)/g' $(GENERATOR_VERSION_FOLDER_PATH)/Version.swift.template > $(GENERATOR_VERSION_FILE_PATH)
@@ -41,6 +41,8 @@ publish:
 	git push origin master
 	git tag $(NEW_VERSION_TAG)
 	git push origin $(NEW_VERSION_TAG)
+
+publish:
 	brew update && brew bump-formula-pr --tag=$(NEW_VERSION_TAG) --revision=$(shell git rev-parse HEAD) needle
 	pod trunk push
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ release:
 	git push origin $(NEW_VERSION_TAG)
 
 publish:
-	brew update && brew bump-formula-pr --tag=$(NEW_VERSION_TAG) --revision=$(shell git rev-parse HEAD) needle
+	brew update && brew bump-formula-pr --tag=$(shell git describe --tags) --revision=$(shell git rev-parse HEAD) needle
 	pod trunk push --allow-warnings
 
 archive_generator: clean build

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,16 +2,14 @@
 *This page contains instructions for admins of this project to release a new version.*
 
 ## Run Makefile
-Run `$ make publish VERSION_NUMBER` at the root directory of needle (where the `Makefile` is located)
+1. Run `$ make release VERSION_NUMBER` at the root directory of needle (where the `Makefile` is located)
 
-For example:
-```
-$ make publish 0.13.0
-```
+    For example:
+    ```
+    $ make release 0.13.0
+    ```
 
-This runs the steps specified in the `Makefile`.
-
-The `Makefile` does not support failure recovery yet. If a certain step fails, you need to resolve it and manually run the remaining steps.
+2. Run `$ make publish` to publish the release to various destinatinos (like CocoaPods and Homebrew).
 
 ## Create a new Github release
 After all the steps in the `Makefile` finish successfully, go to the Releases tab and create a new release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@
     $ make release 0.13.0
     ```
 
-2. Run `$ make publish` to publish the release to various destinatinos (like CocoaPods and Homebrew).
+2. Run `$ make publish` to publish the release to various destinations (like CocoaPods and Homebrew).
 
 ## Create a new Github release
 After all the steps in the `Makefile` finish successfully, go to the Releases tab and create a new release.


### PR DESCRIPTION
Otherwise the git rev-parse still gets a stale commit (the commit before version number is bumped).
Also allow warnings for `pod trunk push`. Seems like xcodebuild is confused about a file's target membership.