### PR TITLE
Publish both needle binary and swiftsyntax dylib to homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ clean:
 build:
 	cd $(GENERATOR_FOLDER) && swift build $(SWIFT_BUILD_FLAGS)
 
-install: uninstall clean build
+install: uninstall clean build archive_generator
 	install -d "$(BINARY_FOLDER)"
-	install "$(GENERATOR_ARCHIVE_PATH)" "$(BINARY_FOLDER)"
+	install "$(GENERATOR_FOLDER)/bin/needle" "$(GENERATOR_FOLDER)/bin/$(SWIFT_SYNTAX_DYLIB)" "$(BINARY_FOLDER)"
 
 uninstall:
 	rm -f "$(BINARY_FOLDER)/needle"


### PR DESCRIPTION
Homebrew's [needle formula](https://github.com/Homebrew/homebrew-core/blob/56eecbf3d8b418bcc6589bb8a9c9b866bc8d2270/Formula/needle.rb) uses `make install` to install the tool.

We need both the needle binary and the SwiftSyntax dylib to be available in the installed directory.

Once we merge this, we should be able to update the formula to fix Homebrew distribution (#374)