### PR TITLE
Github Actions - Use MacOS11 and Xcode 12.5.1 on runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: macOS-11
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: "NeedleFoundationTests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_12.5.1.app
+
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - uses: actions/checkout@v2
       - name: "NeedleFoundationTests"


### PR DESCRIPTION
In order to support Xcode 12.5.1, we need to bump our runners to use macOS 11. 

This will resolve the jobs for https://github.com/uber/needle/pull/389.

Specifying an Xcode version on a github runner was done by following https://www.jessesquires.com/blog/2020/01/06/selecting-an-xcode-version-on-github-ci/