### PR TITLE
Decide SwiftSyntax version dynamically based on Swift version

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -1,6 +1,21 @@
 // swift-tools-version:5.1
 import PackageDescription
 
+// Define the SwiftSyntax release to use based on the version of Swift in use
+#if swift(>=5.5) && swift(<5.6)
+// Xcode 13.0 / Swift 5.5
+let swiftSyntaxVersion: Version = "0.50500.0"
+#elseif swift(>=5.4)
+// Xcode 12.5 / Swift 5.4
+let swiftSyntaxVersion: Version = "0.50400.0"
+#elseif swift(>=5.3)
+// Xcode 12.0 / Swift 5.3
+let swiftSyntaxVersion: Version = "0.50300.0"
+#elseif swift(>=5.2)
+// Xcode 11.4 / Swift 5.2
+let swiftSyntaxVersion: Version = "0.50200.0"
+#endif
+
 let package = Package(
     name: "Needle",
     products: [
@@ -11,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.1.5")),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
         .package(url: "https://github.com/uber/swift-common.git", .exact("0.5.0")),
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact(swiftSyntaxVersion)),
     ],
     targets: [
         .target(


### PR DESCRIPTION
(I'm not familiar yet with how this project is built, so I'm opening this as a draft to get some feedback on the approach.)

I know there have been issues in the past around needing to update the SwiftSyntax version of the generator in order to support new Swift/Xcode versions. Would an approach like this allow the version to be dynamically selected based off of what version of Swift/Xcode is being used?