### PR TITLE
Add Swift 5.5. binary

### DIFF
--- a/GENERATOR.md
+++ b/GENERATOR.md
@@ -51,6 +51,10 @@ brew install needle
 ```
 Once installed the generator binary can be executed directly as `$ needle version`.
 
+### Build from source
+
+As Swift and Xcode releases progress, the repository may not contain the toolchain veresion you are using. In this case, you can build the generator binary from source. Please see [Generator README](https://github.com/uber/needle/blob/master/GENERATOR.md) for details.
+
 ## Xcode integration
 
 Even though Needle's generator can be invoked from the commandline, it is most convenient when it's directly integrated with the build system. At Uber we use [BUCK](https://buckbuild.com/) for CI builds and Xcode for local development. Therefore for us, Needle is integrated with BUCK. We then make Xcode invoke our BUCK Needle target for code generation. Since the vast marjority of Swift applications use Xcode as the build system, we'll cover this here.

--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.1.5")),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
         .package(url: "https://github.com/uber/swift-common.git", .exact("0.5.0")),
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0")),
     ],
     targets: [
         .target(

--- a/Generator/README.md
+++ b/Generator/README.md
@@ -13,7 +13,7 @@ $ swift package update
 You can then build from the command-line:
 
 ```
-$ swift build
+$ swift build -c release
 ```
 
 Or create an Xcode project and build using the IDE:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Regardless of how the `NeedleFoundation` framework is integrated into your proje
 brew install needle
 ```
 
+#### Build from source
+
+As Swift and Xcode releases progress, the repository may not contain the toolchain veresion you are using. In this case, you can build the generator binary from source. Please see [Generator README](https://github.com/uber/needle/blob/master/GENERATOR.md) for details.
+
 ## [Why use dependency injection?](./WHY_DI.md)
 
 The linked document uses a somewhat real example to explain what the dependency injection pattern is, and its benefits.


### PR DESCRIPTION
Also updated READMEs to explain how to use the generator in case the user is using a Swift version not supported by the current releases in the repo.