### PR TITLE
Add support for Swift 5.6 beta

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.1.5")),
         .package(url: "https://github.com/uber/swift-concurrency.git", .upToNextMajor(from: "0.6.5")),
         .package(url: "https://github.com/uber/swift-common.git", .exact("0.5.0")),
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .revision("0.50600.0-SNAPSHOT-2022-01-24")),
     ],
     targets: [
         .target(
@@ -21,6 +21,7 @@ let package = Package(
                 "Concurrency",
                 "SourceParsingFramework",
                 "SwiftSyntax",
+                "SwiftSyntaxParser",
             ]),
         .testTarget(
             name: "NeedleFrameworkTests",

--- a/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTProducerTask.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Tasks/ASTProducerTask.swift
@@ -17,7 +17,7 @@
 import Concurrency
 import Foundation
 import SourceParsingFramework
-import SwiftSyntax
+import SwiftSyntaxParser
 
 /// A task that parses a Swift source content and produces Swift AST that
 /// can then be parsed into the dependnecy graph.

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/ASTProducerTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/ASTProducerTaskTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 @testable import NeedleFramework
-import SwiftSyntax
+import SwiftSyntaxParser
 
 class ASTProducerTaskTests: AbstractParserTests {
 

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/DeclarationsParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/DeclarationsParserTaskTests.swift
@@ -17,7 +17,7 @@
 import XCTest
 @testable import NeedleFramework
 @testable import SourceParsingFramework
-import SwiftSyntax
+import SwiftSyntaxParser
 
 class DeclarationsParserTaskTests: AbstractParserTests {
 

--- a/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDeclarationsParserTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Parsing/Pluginized/PluginizedDeclarationsParserTaskTests.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 @testable import NeedleFramework
-import SwiftSyntax
+import SwiftSyntaxParser
 
 class PluginizedDeclarationsParserTaskTests: AbstractParserTests {
 


### PR DESCRIPTION
We are using the 5.6 beta toolchain to address an issue in the current Xcode 13.2.1.