### PR TITLE
Significantly improve compile performance of generated code

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
@@ -58,31 +58,51 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
         var result = [SerializedProvider]()
         let (baseClass, content) = serializedBase(for: providers.first!)
         if providers.first?.isEmptyDependency == false {
-            result.append(SerializedProvider(content: content, registration: ""))
+            result.append(SerializedProvider(content: content, registration: "", attributes: [:]))
         }
         for provider in providers {
-            let content = provider.isEmptyDependency ? "" : serializedContent(for: provider, baseClassSerializer: baseClass)
-            let registration = DependencyProviderRegistrationSerializer(provider: provider).serialize()
-            result.append(SerializedProvider(content: content, registration: registration))
+            let paramsSerializer = DependencyProviderParamsSerializer(provider: provider)
+            let funcNameSerializer = DependencyProviderFuncNameSerializer(classNameSerializer: baseClass, paramsSerializer: paramsSerializer)
+            let content = serializedContent(for: provider, classNameSerializer: baseClass, paramsSerializer: paramsSerializer, funcNameSerializer: funcNameSerializer)
+            let registration = DependencyProviderRegistrationSerializer(provider: provider, factoryFuncNameSerializer: funcNameSerializer).serialize()
+            let attributes = calculateAttributes(for: provider, funcNameSerializer: funcNameSerializer)
+            result.append(SerializedProvider(content: content, registration: registration, attributes: attributes))
         }
         return result
     }
 
-    private func serializedContent(for provider: ProcessedDependencyProvider, baseClassSerializer: Serializer) -> String {
-        let classNameSerializer = DependencyProviderClassNameSerializer(provider: provider)
-        let initBodySerializer = DependencyProviderInitBodySerializer(provider: provider)
-
-        let serializer = DependencyProviderSerializer(provider: provider, classNameSerializer: classNameSerializer, baseClassSerializer: baseClassSerializer, initBodySerializer: initBodySerializer)
-        return serializer.serialize()
+    private func serializedContent(for provider: ProcessedDependencyProvider, classNameSerializer: Serializer, paramsSerializer: Serializer, funcNameSerializer: Serializer) -> String {
+        if provider.isEmptyDependency {
+            return ""
+        }
+        return DependencyProviderFuncSerializer(provider: provider, funcNameSerializer: funcNameSerializer, classNameSerializer: classNameSerializer, paramsSerializer: paramsSerializer).serialize()
     }
 
     private func serializedBase(for provider: ProcessedDependencyProvider) -> (Serializer, String) {
-        let classNameSerializer = DependencyProviderBaseClassNameSerializer(provider: provider)
+        let classNameSerializer = DependencyProviderClassNameSerializer(provider: provider)
         let propertiesSerializer = PropertiesSerializer(processedProperties: provider.processedProperties)
         let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: provider.levelMap.keys.sorted())
         let initBodySerializer = DependencyProviderBaseInitSerializer(provider: provider)
 
-        let serializer = DependencyProviderBaseSerializer(provider: provider, classNameSerializer: classNameSerializer, propertiesSerializer: propertiesSerializer, sourceComponentsSerializer: sourceComponentsSerializer, initBodySerializer: initBodySerializer)
+        let serializer = DependencyProviderClassSerializer(provider: provider, classNameSerializer: classNameSerializer, propertiesSerializer: propertiesSerializer, sourceComponentsSerializer: sourceComponentsSerializer, initBodySerializer: initBodySerializer)
         return (classNameSerializer, serializer.serialize())
+    }
+
+    private func calculateAttributes(for provider: ProcessedDependencyProvider, funcNameSerializer: Serializer) -> [String: String] {
+        if provider.isEmptyDependency {
+            return [:]
+        }
+        var maxLevel: Int = 0
+        provider.levelMap.forEach { (componentType: String, level: Int) in
+            if level > maxLevel {
+                maxLevel = level
+            }
+        }
+        var attributes: [String: String] = [:]
+        if maxLevel > 0 {
+            attributes["maxLevel"] = String(maxLevel)
+        }
+        attributes["factoryName"] = funcNameSerializer.serialize()
+        return attributes
     }
 }

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
@@ -93,7 +93,7 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
             return ProviderAttributes()
         }
         var maxLevel: Int = 0
-        provider.levelMap.forEach { (componentType: String, level: Int) in
+        for (_, level) in provider.levelMap {
             if level > maxLevel {
                 maxLevel = level
             }

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
@@ -56,14 +56,14 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
 
     private func serialize(_ providers: [ProcessedDependencyProvider]) -> [SerializedProvider] {
         var result = [SerializedProvider]()
-        let (baseClass, content) = serializedBase(for: providers.first!)
+        let (classNameSerializer, content) = serializedClass(for: providers.first!)
         if providers.first?.isEmptyDependency == false {
             result.append(SerializedProvider(content: content, registration: "", attributes: [:]))
         }
         for provider in providers {
             let paramsSerializer = DependencyProviderParamsSerializer(provider: provider)
-            let funcNameSerializer = DependencyProviderFuncNameSerializer(classNameSerializer: baseClass, paramsSerializer: paramsSerializer)
-            let content = serializedContent(for: provider, classNameSerializer: baseClass, paramsSerializer: paramsSerializer, funcNameSerializer: funcNameSerializer)
+            let funcNameSerializer = DependencyProviderFuncNameSerializer(classNameSerializer: classNameSerializer, paramsSerializer: paramsSerializer)
+            let content = serializedContent(for: provider, classNameSerializer: classNameSerializer, paramsSerializer: paramsSerializer, funcNameSerializer: funcNameSerializer)
             let registration = DependencyProviderRegistrationSerializer(provider: provider, factoryFuncNameSerializer: funcNameSerializer).serialize()
             let attributes = calculateAttributes(for: provider, funcNameSerializer: funcNameSerializer)
             result.append(SerializedProvider(content: content, registration: registration, attributes: attributes))
@@ -78,7 +78,7 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
         return DependencyProviderFuncSerializer(provider: provider, funcNameSerializer: funcNameSerializer, classNameSerializer: classNameSerializer, paramsSerializer: paramsSerializer).serialize()
     }
 
-    private func serializedBase(for provider: ProcessedDependencyProvider) -> (Serializer, String) {
+    private func serializedClass(for provider: ProcessedDependencyProvider) -> (Serializer, String) {
         let classNameSerializer = DependencyProviderClassNameSerializer(provider: provider)
         let propertiesSerializer = PropertiesSerializer(processedProperties: provider.processedProperties)
         let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: provider.levelMap.keys.sorted())

--- a/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/DependencyProviderSerializerTask.swift
@@ -58,7 +58,7 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
         var result = [SerializedProvider]()
         let (classNameSerializer, content) = serializedClass(for: providers.first!)
         if providers.first?.isEmptyDependency == false {
-            result.append(SerializedProvider(content: content, registration: "", attributes: [:]))
+            result.append(SerializedProvider(content: content, registration: "", attributes: ProviderAttributes()))
         }
         for provider in providers {
             let paramsSerializer = DependencyProviderParamsSerializer(provider: provider)
@@ -88,9 +88,9 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
         return (classNameSerializer, serializer.serialize())
     }
 
-    private func calculateAttributes(for provider: ProcessedDependencyProvider, funcNameSerializer: Serializer) -> [String: String] {
+    private func calculateAttributes(for provider: ProcessedDependencyProvider, funcNameSerializer: Serializer) -> ProviderAttributes {
         if provider.isEmptyDependency {
-            return [:]
+            return ProviderAttributes()
         }
         var maxLevel: Int = 0
         provider.levelMap.forEach { (componentType: String, level: Int) in
@@ -98,11 +98,11 @@ class DependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
                 maxLevel = level
             }
         }
-        var attributes: [String: String] = [:]
+        var attributes = ProviderAttributes()
         if maxLevel > 0 {
-            attributes["maxLevel"] = String(maxLevel)
+            attributes.maxLevel = maxLevel
         }
-        attributes["factoryName"] = funcNameSerializer.serialize()
+        attributes.factoryName = funcNameSerializer.serialize()
         return attributes
     }
 }

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionSerializerTask.swift
@@ -36,7 +36,7 @@ class PluginExtensionSerializerTask : AbstractTask<SerializedProvider> {
     override func execute() -> SerializedProvider {
         let content = PluginExtensionContentSerializer(component: component).serialize()
         let registration = PluginExtensionRegistrationSerializer(component: component).serialize()
-        return SerializedProvider(content: content, registration: registration, attributes: [:])
+        return SerializedProvider(content: content, registration: registration, attributes: ProviderAttributes())
     }
 
     // MARK: - Private

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionSerializerTask.swift
@@ -36,7 +36,7 @@ class PluginExtensionSerializerTask : AbstractTask<SerializedProvider> {
     override func execute() -> SerializedProvider {
         let content = PluginExtensionContentSerializer(component: component).serialize()
         let registration = PluginExtensionRegistrationSerializer(component: component).serialize()
-        return SerializedProvider(content: content, registration: registration)
+        return SerializedProvider(content: content, registration: registration, attributes: [:])
     }
 
     // MARK: - Private

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
@@ -59,7 +59,7 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
         var result = [SerializedProvider]()
         let (classNameSerializer, content) = serializedClass(for: providers.first!, counter: baseCounter)
         if providers.first?.data.isEmptyDependency == false {
-            result.append(SerializedProvider(content: content, registration: "", attributes: [:]))
+            result.append(SerializedProvider(content: content, registration: "", attributes: ProviderAttributes()))
         }
         for (_, provider) in providers.enumerated() {
             let paramsSerializer = DependencyProviderParamsSerializer(provider: provider.data)
@@ -89,9 +89,9 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
         return (classNameSerializer, serializer.serialize())
     }
 
-    private func calculateAttributes(for provider: ProcessedDependencyProvider, funcNameSerializer: Serializer) -> [String: String] {
+    private func calculateAttributes(for provider: ProcessedDependencyProvider, funcNameSerializer: Serializer) -> ProviderAttributes {
         if provider.isEmptyDependency {
-            return [:]
+            return ProviderAttributes()
         }
         var maxLevel: Int = 0
         provider.levelMap.forEach { (componentType: String, level: Int) in
@@ -99,11 +99,11 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
                 maxLevel = level
             }
         }
-        var attributes: [String: String] = [:]
+        var attributes = ProviderAttributes()
         if maxLevel > 0 {
-            attributes["maxLevel"] = String(maxLevel)
+            attributes.maxLevel = maxLevel
         }
-        attributes["factoryName"] = funcNameSerializer.serialize()
+        attributes.factoryName = funcNameSerializer.serialize()
         return attributes
     }
 }

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
@@ -57,14 +57,14 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
 
     private func serialize(_ providers: [PluginizedProcessedDependencyProvider], baseCounter: Int) -> [SerializedProvider] {
         var result = [SerializedProvider]()
-        let (baseClass, content) = serializedBase(for: providers.first!, counter: baseCounter)
+        let (classNameSerializer, content) = serializedClass(for: providers.first!, counter: baseCounter)
         if providers.first?.data.isEmptyDependency == false {
             result.append(SerializedProvider(content: content, registration: "", attributes: [:]))
         }
         for (_, provider) in providers.enumerated() {
             let paramsSerializer = DependencyProviderParamsSerializer(provider: provider.data)
-            let funcNameSerializer = DependencyProviderFuncNameSerializer(classNameSerializer: baseClass, paramsSerializer: paramsSerializer)
-            let content = serializedContent(for: provider, classNameSerializer: baseClass, paramsSerializer: paramsSerializer, funcNameSerializer: funcNameSerializer)
+            let funcNameSerializer = DependencyProviderFuncNameSerializer(classNameSerializer: classNameSerializer, paramsSerializer: paramsSerializer)
+            let content = serializedContent(for: provider, classNameSerializer: classNameSerializer, paramsSerializer: paramsSerializer, funcNameSerializer: funcNameSerializer)
             let registration = DependencyProviderRegistrationSerializer(provider: provider.data, factoryFuncNameSerializer: funcNameSerializer).serialize()
             let attributes = calculateAttributes(for: provider.data, funcNameSerializer: funcNameSerializer)
             result.append(SerializedProvider(content: content, registration: registration, attributes: attributes))
@@ -79,7 +79,7 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
         return DependencyProviderFuncSerializer(provider: provider.data, funcNameSerializer: funcNameSerializer, classNameSerializer: classNameSerializer, paramsSerializer: paramsSerializer).serialize()
     }
 
-    private func serializedBase(for provider: PluginizedProcessedDependencyProvider, counter: Int) -> (Serializer, String) {
+    private func serializedClass(for provider: PluginizedProcessedDependencyProvider, counter: Int) -> (Serializer, String) {
         let classNameSerializer = DependencyProviderClassNameSerializer(provider: provider.data)
         let propertiesSerializer = PluginizedPropertiesSerializer(provider: provider)
         let sourceComponentsSerializer = SourceComponentsSerializer(componentTypes: provider.data.levelMap.keys.sorted())

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDependencyProviderSerializerTask.swift
@@ -94,7 +94,7 @@ class PluginizedDependencyProviderSerializerTask: AbstractTask<[SerializedProvid
             return ProviderAttributes()
         }
         var maxLevel: Int = 0
-        provider.levelMap.forEach { (componentType: String, level: Int) in
+        for (_, level) in provider.levelMap {
             if level > maxLevel {
                 maxLevel = level
             }

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderClassNameSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderClassNameSerializer.swift
@@ -16,31 +16,35 @@
 
 import Foundation
 
-/// A serializer that produces the class name for the dependency provider.
-class DependencyProviderClassNameSerializer: Serializer {
+/// A serializer that produces the func name for the dependency provider.
+class DependencyProviderFuncNameSerializer: Serializer {
 
     /// Initializer.
     ///
-    /// - parameter provider: The provider to generate class name for.
-    init(provider: ProcessedDependencyProvider) {
-        self.provider = provider
+    /// - parameter classNameSerializer: The serializer for the class name.
+    /// - parameter paramsSerializer: The serializer for the parameters.
+    init(classNameSerializer: Serializer, paramsSerializer: Serializer) {
+        self.classNameSerializer = classNameSerializer
+        self.paramsSerializer = paramsSerializer
     }
 
-    /// Serialize the data model and produce the class name code.
+    /// Serialize the data model and produce the func name code.
     ///
-    /// - returns: The class name code.
+    /// - returns: The func name code.
     func serialize() -> String {
-        let pathId = String(provider.unprocessed.pathString.shortSHA256Value)
-        return "\(provider.unprocessed.dependency.name)\(pathId)Provider"
+        let classId = String(classNameSerializer.serialize().shortSHA256Value)
+        let paramsId = String(paramsSerializer.serialize().shortSHA256Value)
+        return "factory\(classId)\(paramsId)"
     }
 
     // MARK: - Private
 
-    private let provider: ProcessedDependencyProvider
+    private let classNameSerializer: Serializer
+    private let paramsSerializer: Serializer
 }
 
 /// A serializer that produces the class name for the dependency provider base class.
-final class DependencyProviderBaseClassNameSerializer: Serializer {
+final class DependencyProviderClassNameSerializer: Serializer {
 
     /// Initializer.
     ///
@@ -55,7 +59,7 @@ final class DependencyProviderBaseClassNameSerializer: Serializer {
     /// - returns: The class name code.
     func serialize() -> String {
         let pathId = String(provider.unprocessed.pathString.shortSHA256Value)
-        return "\(provider.unprocessed.dependency.name)\(pathId)BaseProvider"
+        return "\(provider.unprocessed.dependency.name)\(pathId)Provider"
     }
 
     // MARK: - Private

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderClassSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderClassSerializer.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A serializer that produces the source code for the entire dependency
 /// provider.
-final class DependencyProviderBaseSerializer: Serializer {
+final class DependencyProviderClassSerializer: Serializer {
 
     /// Initializer.
     ///

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderParamsSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderParamsSerializer.swift
@@ -16,39 +16,27 @@
 
 import Foundation
 
-/// A serializer that produces the initializer body code for the dependency
+/// A serializer that produces the params to pass to the dependency
 /// provider.
-class DependencyProviderBaseInitSerializer: Serializer {
+final class DependencyProviderParamsSerializer: Serializer {
 
     /// Initializer.
     ///
-    /// - parameter provider: The provider to generate initializer body
-    /// source code for.
+    /// - parameter provider: The provider to generate params source code for.
     init(provider: ProcessedDependencyProvider) {
         self.provider = provider
     }
 
-    /// Serialize the data model and produce the initializer body code.
+    /// Serialize the data model and produce the params code.
     ///
-    /// - returns: The initializer body source code.
+    /// - returns: The params source code.
     func serialize() -> String {
-        let arguments = provider.levelMap
+        return provider.levelMap
             .sorted(by: { $0.key < $1.key })
             .map { (componentType: String, level: Int) in
-                return "\(componentType.lowercasedFirstChar()): \(componentType)"
+                return "\(componentType.lowercasedFirstChar()): parent\(level)(component) as! \(componentType)"
         }
         .joined(separator: ", ")
-        let body = provider.levelMap
-            .sorted(by: { $0.key < $1.key })
-            .map { (componentType: String, level: Int) in
-            return "        self.\(componentType.lowercasedFirstChar()) = \(componentType.lowercasedFirstChar())"
-        }
-        .joined(separator: "\n")
-        return """
-    init(\(arguments)) {
-\(body)
-    }
-"""
     }
 
     // MARK: - Private

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderParamsSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderParamsSerializer.swift
@@ -14,8 +14,6 @@
 //  limitations under the License.
 //
 
-import Foundation
-
 /// A serializer that produces the params to pass to the dependency
 /// provider.
 final class DependencyProviderParamsSerializer: Serializer {

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderRegistrationSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderRegistrationSerializer.swift
@@ -23,24 +23,25 @@ class DependencyProviderRegistrationSerializer: Serializer {
     /// Initializer.
     ///
     /// - parameter provider: The provider to generate registration code
+    /// - parameter factoryFuncNameSerializer: The serializer to generate the factory func name
     /// for.
-    init(provider: ProcessedDependencyProvider) {
+    init(provider: ProcessedDependencyProvider, factoryFuncNameSerializer: Serializer) {
         self.provider = provider
+        self.factoryFuncNameSerializer = factoryFuncNameSerializer
     }
 
     /// Serialize the data model and produce the registration source code.
     ///
     /// - returns: The registration source code.
     func serialize() -> String {
-        let providerName = provider.isEmptyDependency ? "EmptyDependencyProvider" : DependencyProviderClassNameSerializer(provider: provider).serialize()
+        let factoryName = provider.isEmptyDependency ? "factoryEmptyDependencyProvider" : factoryFuncNameSerializer.serialize()
         return """
-        __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "\(provider.unprocessed.pathString)") { component in
-            return \(providerName)(component: component)
-        }\n
+        registerProviderFactory("\(provider.unprocessed.pathString)", \(factoryName))\n
         """
     }
 
     // MARK: - Private
 
     private let provider: ProcessedDependencyProvider
+    private let factoryFuncNameSerializer: Serializer
 }

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyProviderSerializer.swift
@@ -18,14 +18,14 @@ import Foundation
 
 /// A serializer that produces the source code for the dependency
 /// provider. It's mostly empty as the core logic lives in the
-/// superclass
-class DependencyProviderSerializer: Serializer {
+/// class.
+class DependencyProviderFuncSerializer: Serializer {
 
-    init(provider: ProcessedDependencyProvider, classNameSerializer: Serializer, baseClassSerializer: Serializer, initBodySerializer: Serializer) {
-        self.classNameSerializer = classNameSerializer
-        self.baseClassSerializer = baseClassSerializer
-        self.initBodySerializer = initBodySerializer
+    init(provider: ProcessedDependencyProvider, funcNameSerializer: Serializer, classNameSerializer: Serializer, paramsSerializer: Serializer) {
         self.provider = provider
+        self.funcNameSerializer = funcNameSerializer
+        self.classNameSerializer = classNameSerializer
+        self.paramsSerializer = paramsSerializer
     }
 
     /// Serialize the data model and produce the entire dependency provider
@@ -35,10 +35,8 @@ class DependencyProviderSerializer: Serializer {
     func serialize() -> String {
         return """
 /// \(provider.unprocessed.pathString)
-private class \(classNameSerializer.serialize()): \(baseClassSerializer.serialize()) {
-    init(component: NeedleFoundation.Scope) {
-        super.init(\(initBodySerializer.serialize()))
-    }
+private func \(funcNameSerializer.serialize())(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return \(classNameSerializer.serialize())(\(paramsSerializer.serialize()))
 }\n
 """
     }
@@ -46,7 +44,7 @@ private class \(classNameSerializer.serialize()): \(baseClassSerializer.serializ
     // MARK: - Private
 
     private let provider: ProcessedDependencyProvider
+    private let funcNameSerializer: Serializer
     private let classNameSerializer: Serializer
-    private let baseClassSerializer: Serializer
-    private let initBodySerializer: Serializer
+    private let paramsSerializer: Serializer
 }

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
@@ -46,12 +46,12 @@ class OutputSerializer: Serializer {
 
         let providersSection = providers
             .map { (provider: SerializedProvider) in
-                if let providerMaxLevel = Int(provider.attributes["maxLevel"] ?? "0") {
+                if let providerMaxLevel = provider.attributes.maxLevel {
                     if providerMaxLevel > maxLevel {
                         maxLevel = providerMaxLevel
                     }
                 }
-                if let factoryName = provider.attributes["factoryName"] {
+                if let factoryName = provider.attributes.factoryName {
                     if registeredFactories.contains(factoryName) {
                         return ""
                     }

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/OutputSerializer.swift
@@ -80,8 +80,8 @@ class OutputSerializer: Serializer {
         // register the dependencies into functions around 50 lines long.
         // Through some basic testing, this seemed to produce the best results.
         let linesPerHelper = 50
-        var registrationHelperFuncs: Array<String> = []
-        let registrations: Array<String> = providers
+        var registrationHelperFuncs: [String] = []
+        let registrations: [String] = providers
             .map { (provider: SerializedProvider) in
                 provider.registration
             }

--- a/Generator/Sources/NeedleFramework/Models/DependencyProvider.swift
+++ b/Generator/Sources/NeedleFramework/Models/DependencyProvider.swift
@@ -53,6 +53,15 @@ struct ProcessedDependencyProvider {
     }
 }
 
+/// Attributes about the code contained in a SerializedProvider
+struct ProviderAttributes {
+    /// How many levels up the tree the provider has to traverse to find its
+    /// dependencies
+    var maxLevel: Int? = nil
+    /// The name of any factory function in the provider's .content
+    var factoryName: String? = nil
+}
+
 /// The data model representing a fully serialized provider ready for
 /// export.
 struct SerializedProvider {
@@ -61,5 +70,5 @@ struct SerializedProvider {
     /// The dependency provider registration code.
     let registration: String
     /// Data about the content
-    let attributes: [String: String]
+    let attributes: ProviderAttributes
 }

--- a/Generator/Sources/NeedleFramework/Models/DependencyProvider.swift
+++ b/Generator/Sources/NeedleFramework/Models/DependencyProvider.swift
@@ -60,4 +60,6 @@ struct SerializedProvider {
     let content: String
     /// The dependency provider registration code.
     let registration: String
+    /// Data about the content
+    let attributes: [String: String]
 }

--- a/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderSerializerTaskTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/DependencyProviderSerializerTaskTests.swift
@@ -40,80 +40,60 @@ class DependencyProviderSerializerTaskTests: AbstractGeneratorTests {
         switch provider.unprocessed.pathString {
         case "^->RootComponent->LoggedInComponent->GameComponent":
             XCTAssertEqual(serializedProviders[1].registration, """
-__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent") { component in
-    return GameDependency1ab5926a977f706d3195Provider(component: component)
-}
+registerProviderFactory("^->RootComponent->LoggedInComponent->GameComponent", factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e)
 
 """)
             XCTAssertEqual(serializedProviders[1].content, """
 /// ^->RootComponent->LoggedInComponent->GameComponent
-private class GameDependency1ab5926a977f706d3195Provider: GameDependency1ab5926a977f706d3195BaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent as! LoggedInComponent, rootComponent: component.parent.parent as! RootComponent)
-    }
+private func factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return GameDependency1ab5926a977f706d3195Provider(loggedInComponent: parent1(component) as! LoggedInComponent, rootComponent: parent2(component) as! RootComponent)
 }
 
 """)
         case "^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent":
             XCTAssertEqual(serializedProviders[1].registration, """
-__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent\") { component in
-    return ScoreSheetDependency97f2595a691a56781aaaProvider(component: component)
-}
+registerProviderFactory("^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent", factory3f7d60e2119708f293bac0d8c882e1e0d9b5eda1)
 
 """)
             XCTAssertEqual(serializedProviders[1].content, """
 /// ^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent
-private class ScoreSheetDependency97f2595a691a56781aaaProvider: ScoreSheetDependency97f2595a691a56781aaaBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent.parent as! LoggedInComponent)
-    }
+private func factory3f7d60e2119708f293bac0d8c882e1e0d9b5eda1(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependency97f2595a691a56781aaaProvider(loggedInComponent: parent2(component) as! LoggedInComponent)
 }
 
 """)
         case "^->RootComponent->LoggedInComponent->ScoreSheetComponent":
             XCTAssertEqual(serializedProviders[1].registration, """
-__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->ScoreSheetComponent\") { component in
-    return ScoreSheetDependencycbd7fa4bae2ee69a1926Provider(component: component)
-}
+registerProviderFactory("^->RootComponent->LoggedInComponent->ScoreSheetComponent", factory62cd15b035cb1b1ab3e00b20504d5a9e5588d7b3)
 
 """)
             XCTAssertEqual(serializedProviders[1].content, """
 /// ^->RootComponent->LoggedInComponent->ScoreSheetComponent
-private class ScoreSheetDependencycbd7fa4bae2ee69a1926Provider: ScoreSheetDependencycbd7fa4bae2ee69a1926BaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent as! LoggedInComponent)
-    }
+private func factory62cd15b035cb1b1ab3e00b20504d5a9e5588d7b3(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependencycbd7fa4bae2ee69a1926Provider(loggedInComponent: parent1(component) as! LoggedInComponent)
 }
 
 """)
         case "^->RootComponent->LoggedOutComponent":
             XCTAssertEqual(serializedProviders[1].registration, """
-__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in
-    return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)
-}
+registerProviderFactory("^->RootComponent->LoggedOutComponent", factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e)
 
 """)
             XCTAssertEqual(serializedProviders[1].content, """
 /// ^->RootComponent->LoggedOutComponent
-private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependencyacada53ea78d270efa2fBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(rootComponent: component.parent as! RootComponent)
-    }
+private func factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return LoggedOutDependencyacada53ea78d270efa2fProvider(rootComponent: parent1(component) as! RootComponent)
 }
 
 """)
         case "^->RootComponent->LoggedInComponent":
             XCTAssertEqual(serializedProviders[0].registration, """
-__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in
-    return EmptyDependencyProvider(component: component)
-}
+registerProviderFactory("^->RootComponent->LoggedInComponent", factoryEmptyDependencyProvider)
 
 """)
         case "^->RootComponent":
             XCTAssertEqual(serializedProviders[0].registration, """
-__DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in
-    return EmptyDependencyProvider(component: component)
-}
+registerProviderFactory("^->RootComponent", factoryEmptyDependencyProvider)
 
 """)
         default:

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
@@ -52,44 +52,28 @@ class PluginizedDependencyGraphExporterTests: AbstractPluginizedGeneratorTests {
         XCTAssertTrue(generated.contains("private let needleDependenciesHash : String? = \"f7e65514498ad4f99ae8eb589dd36bbc\""))
         XCTAssertTrue(generated.contains("// MARK: - Registration"))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedOutComponent\") { component in
-        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)
-    }
+    registerProviderFactory(\"^->RootComponent->LoggedOutComponent\", factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e)
 """))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent\") { component in
-        return EmptyDependencyProvider(component: component)
-    }
+    registerProviderFactory("^->RootComponent", factoryEmptyDependencyProvider)
 """))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent\") { component in
-        return ScoreSheetDependencyea879b8e06763171478bProvider(component: component)
-    }
+    registerProviderFactory(\"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent\", factoryb11b7d1dec7e3c9b3dca49b41e44e0ed6a6f8eaf)
 """))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent\") { component in
-        return ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider(component: component)
-    }
+    registerProviderFactory(\"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent\", factory3306c50e89e2421d0b0c65d055996113f3c13de1)
 """))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent\") { component in
-        return EmptyDependencyProvider(component: component)
-    }
+    registerProviderFactory(\"^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent\", factoryEmptyDependencyProvider)
 """))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent\") { component in
-        return EmptyDependencyProvider(component: component)
-    }
+    registerProviderFactory(\"^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent\", factoryEmptyDependencyProvider)
 """))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent->GameComponent\") { component in
-        return GameDependency1ab5926a977f706d3195Provider(component: component)
-    }
+    registerProviderFactory(\"^->RootComponent->LoggedInComponent->GameComponent\", factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e)
 """))
         XCTAssertTrue(generated.contains("""
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: \"^->RootComponent->LoggedInComponent\") { component in
-        return EmptyDependencyProvider(component: component)
-    }
+    registerProviderFactory(\"^->RootComponent->LoggedInComponent\", factoryEmptyDependencyProvider)
 """))
         XCTAssertTrue(generated.contains("""
     __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: \"GameComponent\") { component in
@@ -101,9 +85,27 @@ class PluginizedDependencyGraphExporterTests: AbstractPluginizedGeneratorTests {
         return LoggedInPluginExtensionProvider(component: component)
     }
 """))
+        XCTAssertTrue(generated.contains("// MARK: - Traversal Helpers"))
+        XCTAssertTrue(generated.contains("""
+private func parent1(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent
+}
+"""))
+        XCTAssertTrue(generated.contains("""
+private func parent2(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent.parent
+}
+"""))
+        XCTAssertTrue(generated.contains("""
+private func parent3(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent.parent.parent
+}
+"""))
+        XCTAssertFalse(generated.contains("private func parent4(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {"))
+        XCTAssertTrue(generated.contains("// MARK: - Traversal Helpers"))
         XCTAssertTrue(generated.contains("// MARK: - Providers"))
         XCTAssertTrue(generated.contains("""
-private class LoggedOutDependencyacada53ea78d270efa2fBaseProvider: LoggedOutDependency {
+private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependency {
     var mutablePlayersStream: MutablePlayersStream {
         return rootComponent.mutablePlayersStream
     }
@@ -113,14 +115,12 @@ private class LoggedOutDependencyacada53ea78d270efa2fBaseProvider: LoggedOutDepe
     }
 }
 /// ^->RootComponent->LoggedOutComponent
-private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependencyacada53ea78d270efa2fBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(rootComponent: component.parent as! RootComponent)
-    }
+private func factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return LoggedOutDependencyacada53ea78d270efa2fProvider(rootComponent: parent1(component) as! RootComponent)
 }
 """))
         XCTAssertTrue(generated.contains("""
-private class ScoreSheetDependencyea879b8e06763171478bBaseProvider: ScoreSheetDependency {
+private class ScoreSheetDependencyea879b8e06763171478bProvider: ScoreSheetDependency {
     var scoreStream: ScoreStream {
         return (loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent).scoreStream
     }
@@ -130,14 +130,12 @@ private class ScoreSheetDependencyea879b8e06763171478bBaseProvider: ScoreSheetDe
     }
 }
 /// ^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent
-private class ScoreSheetDependencyea879b8e06763171478bProvider: ScoreSheetDependencyea879b8e06763171478bBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent.parent.parent as! LoggedInComponent)
-    }
+private func factoryb11b7d1dec7e3c9b3dca49b41e44e0ed6a6f8eaf(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependencyea879b8e06763171478bProvider(loggedInComponent: parent3(component) as! LoggedInComponent)
 }
 """))
         XCTAssertTrue(generated.contains("""
-private class ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider: ScoreSheetDependency {
+private class ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider: ScoreSheetDependency {
     var scoreStream: ScoreStream {
         return loggedInNonCoreComponent.scoreStream
     }
@@ -147,14 +145,12 @@ private class ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider: ScoreSheetDe
     }
 }
 /// ^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent
-private class ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider: ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInNonCoreComponent: component.parent as! LoggedInNonCoreComponent)
-    }
+private func factory3306c50e89e2421d0b0c65d055996113f3c13de1(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider(loggedInNonCoreComponent: parent1(component) as! LoggedInNonCoreComponent)
 }
 """))
         XCTAssertTrue(generated.contains("""
-private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
+private class GameDependency1ab5926a977f706d3195Provider: GameDependency {
     var mutableScoreStream: MutableScoreStream {
         return loggedInComponent.pluginExtension.mutableScoreStream
     }
@@ -169,10 +165,8 @@ private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
     }
 }
 /// ^->RootComponent->LoggedInComponent->GameComponent
-private class GameDependency1ab5926a977f706d3195Provider: GameDependency1ab5926a977f706d3195BaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent as! LoggedInComponent, rootComponent: component.parent.parent as! RootComponent)
-    }
+private func factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return GameDependency1ab5926a977f706d3195Provider(loggedInComponent: parent1(component) as! LoggedInComponent, rootComponent: parent2(component) as! RootComponent)
 }
 """))
         XCTAssertTrue(generated.contains("""

--- a/Sample/MVC/TicTacToe/Sources/NeedleGenerated.swift
+++ b/Sample/MVC/TicTacToe/Sources/NeedleGenerated.swift
@@ -21,33 +21,19 @@ import UIKit
 // swiftlint:disable unused_declaration
 private let needleDependenciesHash : String? = nil
 
-// MARK: - Registration
+// MARK: - Traversal Helpers
 
-public func registerProviderFactories() {
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent") { component in
-        return GameDependency1ab5926a977f706d3195Provider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent") { component in
-        return ScoreSheetDependency97f2595a691a56781aaaProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->ScoreSheetComponent") { component in
-        return ScoreSheetDependencycbd7fa4bae2ee69a1926Provider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedOutComponent") { component in
-        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent") { component in
-        return EmptyDependencyProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent") { component in
-        return EmptyDependencyProvider(component: component)
-    }
-    
+private func parent1(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent
+}
+
+private func parent2(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent.parent
 }
 
 // MARK: - Providers
 
-private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
+private class GameDependency1ab5926a977f706d3195Provider: GameDependency {
     var mutableScoreStream: MutableScoreStream {
         return loggedInComponent.mutableScoreStream
     }
@@ -62,12 +48,10 @@ private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
     }
 }
 /// ^->RootComponent->LoggedInComponent->GameComponent
-private class GameDependency1ab5926a977f706d3195Provider: GameDependency1ab5926a977f706d3195BaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent as! LoggedInComponent, rootComponent: component.parent.parent as! RootComponent)
-    }
+private func factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return GameDependency1ab5926a977f706d3195Provider(loggedInComponent: parent1(component) as! LoggedInComponent, rootComponent: parent2(component) as! RootComponent)
 }
-private class ScoreSheetDependency97f2595a691a56781aaaBaseProvider: ScoreSheetDependency {
+private class ScoreSheetDependency97f2595a691a56781aaaProvider: ScoreSheetDependency {
     var scoreStream: ScoreStream {
         return loggedInComponent.scoreStream
     }
@@ -77,18 +61,14 @@ private class ScoreSheetDependency97f2595a691a56781aaaBaseProvider: ScoreSheetDe
     }
 }
 /// ^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent
-private class ScoreSheetDependency97f2595a691a56781aaaProvider: ScoreSheetDependency97f2595a691a56781aaaBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent.parent as! LoggedInComponent)
-    }
+private func factory3f7d60e2119708f293bac0d8c882e1e0d9b5eda1(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependency97f2595a691a56781aaaProvider(loggedInComponent: parent2(component) as! LoggedInComponent)
 }
 /// ^->RootComponent->LoggedInComponent->ScoreSheetComponent
-private class ScoreSheetDependencycbd7fa4bae2ee69a1926Provider: ScoreSheetDependency97f2595a691a56781aaaBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent as! LoggedInComponent)
-    }
+private func factory3f7d60e2119708f293ba0b20504d5a9e5588d7b3(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependency97f2595a691a56781aaaProvider(loggedInComponent: parent1(component) as! LoggedInComponent)
 }
-private class LoggedOutDependencyacada53ea78d270efa2fBaseProvider: LoggedOutDependency {
+private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependency {
     var mutablePlayersStream: MutablePlayersStream {
         return rootComponent.mutablePlayersStream
     }
@@ -98,8 +78,29 @@ private class LoggedOutDependencyacada53ea78d270efa2fBaseProvider: LoggedOutDepe
     }
 }
 /// ^->RootComponent->LoggedOutComponent
-private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependencyacada53ea78d270efa2fBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(rootComponent: component.parent as! RootComponent)
-    }
+private func factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return LoggedOutDependencyacada53ea78d270efa2fProvider(rootComponent: parent1(component) as! RootComponent)
+}
+
+
+private func factoryEmptyDependencyProvider(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return EmptyDependencyProvider(component: component)
+}
+
+// MARK: - Registration
+private func registerProviderFactory(_ componentPath: String, _ factory: @escaping (Scope) -> AnyObject) {
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: componentPath, factory)
+}
+
+private func register1() {
+    registerProviderFactory("^->RootComponent->LoggedInComponent->GameComponent", factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e)
+    registerProviderFactory("^->RootComponent->LoggedInComponent->GameComponent->ScoreSheetComponent", factory3f7d60e2119708f293bac0d8c882e1e0d9b5eda1)
+    registerProviderFactory("^->RootComponent->LoggedInComponent->ScoreSheetComponent", factory3f7d60e2119708f293ba0b20504d5a9e5588d7b3)
+    registerProviderFactory("^->RootComponent->LoggedOutComponent", factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e)
+    registerProviderFactory("^->RootComponent->LoggedInComponent", factoryEmptyDependencyProvider)
+    registerProviderFactory("^->RootComponent", factoryEmptyDependencyProvider)
+}
+
+public func registerProviderFactories() {
+    register1()
 }

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/NeedleGenerated.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/NeedleGenerated.swift
@@ -23,45 +23,23 @@ import UIKit
 // swiftlint:disable unused_declaration
 private let needleDependenciesHash : String? = "f7e65514498ad4f99ae8eb589dd36bbc"
 
-// MARK: - Registration
+// MARK: - Traversal Helpers
 
-public func registerProviderFactories() {
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedOutComponent") { component in
-        return LoggedOutDependencyacada53ea78d270efa2fProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent") { component in
-        return EmptyDependencyProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent") { component in
-        return ScoreSheetDependencyea879b8e06763171478bProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent") { component in
-        return ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent") { component in
-        return EmptyDependencyProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent") { component in
-        return EmptyDependencyProvider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent->GameComponent") { component in
-        return GameDependency1ab5926a977f706d3195Provider(component: component)
-    }
-    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: "^->RootComponent->LoggedInComponent") { component in
-        return EmptyDependencyProvider(component: component)
-    }
-    __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: "GameComponent") { component in
-        return GamePluginExtensionProvider(component: component)
-    }
-    __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: "LoggedInComponent") { component in
-        return LoggedInPluginExtensionProvider(component: component)
-    }
-    
+private func parent1(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent
+}
+
+private func parent2(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent.parent
+}
+
+private func parent3(_ component: NeedleFoundation.Scope) -> NeedleFoundation.Scope {
+    return component.parent.parent.parent
 }
 
 // MARK: - Providers
 
-private class LoggedOutDependencyacada53ea78d270efa2fBaseProvider: LoggedOutDependency {
+private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependency {
     var mutablePlayersStream: MutablePlayersStream {
         return rootComponent.mutablePlayersStream
     }
@@ -71,12 +49,10 @@ private class LoggedOutDependencyacada53ea78d270efa2fBaseProvider: LoggedOutDepe
     }
 }
 /// ^->RootComponent->LoggedOutComponent
-private class LoggedOutDependencyacada53ea78d270efa2fProvider: LoggedOutDependencyacada53ea78d270efa2fBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(rootComponent: component.parent as! RootComponent)
-    }
+private func factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return LoggedOutDependencyacada53ea78d270efa2fProvider(rootComponent: parent1(component) as! RootComponent)
 }
-private class ScoreSheetDependencyea879b8e06763171478bBaseProvider: ScoreSheetDependency {
+private class ScoreSheetDependencyea879b8e06763171478bProvider: ScoreSheetDependency {
     var scoreStream: ScoreStream {
         return (loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent).scoreStream
     }
@@ -86,12 +62,10 @@ private class ScoreSheetDependencyea879b8e06763171478bBaseProvider: ScoreSheetDe
     }
 }
 /// ^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent
-private class ScoreSheetDependencyea879b8e06763171478bProvider: ScoreSheetDependencyea879b8e06763171478bBaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent.parent.parent as! LoggedInComponent)
-    }
+private func factoryb11b7d1dec7e3c9b3dca49b41e44e0ed6a6f8eaf(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependencyea879b8e06763171478bProvider(loggedInComponent: parent3(component) as! LoggedInComponent)
 }
-private class ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider: ScoreSheetDependency {
+private class ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider: ScoreSheetDependency {
     var scoreStream: ScoreStream {
         return loggedInNonCoreComponent.scoreStream
     }
@@ -101,12 +75,10 @@ private class ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider: ScoreSheetDe
     }
 }
 /// ^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent
-private class ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider: ScoreSheetDependency6fb80fa6e1ee31d9ba11BaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInNonCoreComponent: component.parent as! LoggedInNonCoreComponent)
-    }
+private func factory3306c50e89e2421d0b0c65d055996113f3c13de1(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return ScoreSheetDependency6fb80fa6e1ee31d9ba11Provider(loggedInNonCoreComponent: parent1(component) as! LoggedInNonCoreComponent)
 }
-private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
+private class GameDependency1ab5926a977f706d3195Provider: GameDependency {
     var mutableScoreStream: MutableScoreStream {
         return loggedInComponent.pluginExtension.mutableScoreStream
     }
@@ -121,10 +93,8 @@ private class GameDependency1ab5926a977f706d3195BaseProvider: GameDependency {
     }
 }
 /// ^->RootComponent->LoggedInComponent->GameComponent
-private class GameDependency1ab5926a977f706d3195Provider: GameDependency1ab5926a977f706d3195BaseProvider {
-    init(component: NeedleFoundation.Scope) {
-        super.init(loggedInComponent: component.parent as! LoggedInComponent, rootComponent: component.parent.parent as! RootComponent)
-    }
+private func factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return GameDependency1ab5926a977f706d3195Provider(loggedInComponent: parent1(component) as! LoggedInComponent, rootComponent: parent2(component) as! RootComponent)
 }
 /// GameComponent plugin extension
 private class GamePluginExtensionProvider: GamePluginExtension {
@@ -150,4 +120,35 @@ private class LoggedInPluginExtensionProvider: LoggedInPluginExtension {
         let loggedInComponent = component as! LoggedInComponent
         loggedInNonCoreComponent = loggedInComponent.nonCoreComponent as! LoggedInNonCoreComponent
     }
+}
+
+
+private func factoryEmptyDependencyProvider(_ component: NeedleFoundation.Scope) -> AnyObject {
+    return EmptyDependencyProvider(component: component)
+}
+
+// MARK: - Registration
+private func registerProviderFactory(_ componentPath: String, _ factory: @escaping (Scope) -> AnyObject) {
+    __DependencyProviderRegistry.instance.registerDependencyProviderFactory(for: componentPath, factory)
+}
+
+private func register1() {
+    registerProviderFactory("^->RootComponent->LoggedOutComponent", factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e)
+    registerProviderFactory("^->RootComponent", factoryEmptyDependencyProvider)
+    registerProviderFactory("^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent->ScoreSheetComponent", factoryb11b7d1dec7e3c9b3dca49b41e44e0ed6a6f8eaf)
+    registerProviderFactory("^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent->ScoreSheetComponent", factory3306c50e89e2421d0b0c65d055996113f3c13de1)
+    registerProviderFactory("^->RootComponent->LoggedInComponent->GameComponent->GameNonCoreComponent", factoryEmptyDependencyProvider)
+    registerProviderFactory("^->RootComponent->LoggedInComponent->LoggedInNonCoreComponent", factoryEmptyDependencyProvider)
+    registerProviderFactory("^->RootComponent->LoggedInComponent->GameComponent", factorycf9c02c4def4e3d508816cd03d3cf415b70dfb0e)
+    registerProviderFactory("^->RootComponent->LoggedInComponent", factoryEmptyDependencyProvider)
+    __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: "GameComponent") { component in
+        return GamePluginExtensionProvider(component: component)
+    }
+    __PluginExtensionProviderRegistry.instance.registerPluginExtensionProviderFactory(for: "LoggedInComponent") { component in
+        return LoggedInPluginExtensionProvider(component: component)
+    }
+}
+
+public func registerProviderFactories() {
+    register1()
 }


### PR DESCRIPTION
The following commit makes the changes listed below to the generated
code to significantly improve compile speed of the generated code.

On an M1 Max 64GB MacBookPro, with Xcode 13.3 the following improvements
were measured:

 - x86_64 target: 350% faster compile time (~86s -> ~25s)
 - arm64 target: 1600% faster compile time (~360s -> 22s)

Clearly the arm64 target before these changes was a significant
regression from the x86_64 compile times. Thus, alternatively you could
think of this patch as:

 - Fixing an arm64 compile regression with Swift 5.6
 - Improving compile time of generated code by 350%

The changes made to the generated code include:

 1. Helper functions for `.parent` traversal chains
 2. Not using closures when registering factories, instead using named
    functions
 3. Removing class inheritance from the provider code. Instead, factory
    functions are written to perform the exact `.parent` traversal needed.
 4. De-duplicating all factory functions since .parent traversal is
    generic. Thus, any child nodes in the dependency tree that are the
    same level in subtree can use the same factory function.
 5. Reordering code so it is in dependency order.
 6. Adding a helper for registration calls, to remove lots of duplicate
    data structure traversal.
 7. Splitting registration into named functions no more than 50
    statements long. A single function with well over 10k registration
    calls was the primary cause of the arm64 compile time regression.

These changes not only reduced the compile time, but significantly
reduced the amount of code being compiled. In my tests that involved the
numbers below, the generated code went from around 18MB to 10MB.