### PR TITLE
Replace RootComponent with BootstrapComponent

### DIFF
--- a/API.md
+++ b/API.md
@@ -125,7 +125,7 @@ Since the root of a DI tree does not have a parent component, we bootstrap the r
 ```swift
 let rootComponent = RootComponent()
 
-class RootComponent: NeedleFoundation.RootComponent {
+class RootComponent: NeedleFoundation.BootstrapComponent {
     /// Root component code...
 }
 ```


### PR DESCRIPTION
It appears that the code sample in the documentation is incorrect or outdated. The documentation mentions using the `BootstrapComponent` but the `RootComponent` in the code sample subclasses `NeedleFoundation.RootComponent` instead of `BootstrapComponent`.