### PR TITLE
[UPDATE] gitignore OSX -> macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-## OSX
+## macOS
 *.DS_Store
 
 # Xcode Include to support Carthage for the Foundation project.


### PR DESCRIPTION
Description: On June 13, 2016, at WWDC16, OS X was renamed macOS.
