### PR TITLE
New Needle dynamic codepath

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -1,8 +1,8 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 import PackageDescription
 
 // Based on https://github.com/apple/swift-syntax#readme
-#if swift(>=5.6) && swift(<5.7)
+#if swift(>=5.6) && swift(<5.8)
 let swiftSyntaxVersion: Version = "0.50600.1"
 #elseif swift(>=5.5)
 let swiftSyntaxVersion: Version = "0.50500.0"
@@ -47,7 +47,7 @@ let package = Package(
             exclude: [
                 "Fixtures",
             ]),
-        .target(
+        .executableTarget(
             name: "needle",
             dependencies: [
                 "NeedleFramework",

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionDynamicSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionDynamicSerializerTask.swift
@@ -1,8 +1,17 @@
 //
-//  PluginExtensionDynamicSerializerTask.swift
-//  
+//  Copyright (c) 2018. Uber Technologies
 //
-//  Created by Rudro Samanta on 7/1/22.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Concurrency

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionDynamicSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginExtensionDynamicSerializerTask.swift
@@ -1,0 +1,35 @@
+//
+//  PluginExtensionDynamicSerializerTask.swift
+//  
+//
+//  Created by Rudro Samanta on 7/1/22.
+//
+
+import Concurrency
+import Foundation
+
+/// The task that generates the declaration and registration of the
+/// plugin extension provider for a specific pluginized component.
+class PluginExtensionDynamicSerializerTask : AbstractTask<SerializedProvider> {
+
+    /// Initializer.
+    ///
+    /// - parameter component: The pluginized component that requires the
+    /// plugin extension provider.
+    init(component: PluginizedComponent) {
+        self.component = component
+        super.init(id: TaskIds.pluginExtensionSerializerTask.rawValue)
+    }
+
+    /// Execute the task and returns the data model.
+    ///
+    /// - returns: The `SerializedProvider`.
+    override func execute() -> SerializedProvider {
+        let content = PluginExtensionDynamicContentSerializer(component: component).serialize()
+        return SerializedProvider(content: content, registration: "", attributes: ProviderAttributes())
+    }
+
+    // MARK: - Private
+
+    private let component: PluginizedComponent
+}

--- a/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDynamicDependencyProviderSerializerTask.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Pluginized/PluginizedDynamicDependencyProviderSerializerTask.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Concurrency
+import Foundation
+
+/// The task that serializes a list of pluginized processed dependency
+/// providers into exportable foramt.
+class PluginizedDynamicDependencyProviderSerializerTask: AbstractTask<[SerializedProvider]> {
+
+    /// Initializer.
+    ///
+    /// - parameter providers: The pluginized processed dependency provider
+    /// to serialize.
+    init(component: Component, providers: [PluginizedProcessedDependencyProvider]) {
+        self.component = component
+        self.providers = providers
+        super.init(id: TaskIds.pluginizedDependencyProviderSerializerTask.rawValue)
+    }
+
+    /// Execute the task and returns the in-memory serialized dependency
+    /// provider data models.
+    ///
+    /// - returns: The list of `SerializedProvider`.
+    override func execute() -> [SerializedProvider] {
+        guard !providers.isEmpty else {
+            return []
+        }
+        let serilizer = DependencyPropsSerializer(component: component)
+        let result = SerializedProvider(content: serilizer.serialize(), registration: "", attributes: ProviderAttributes())
+        return [result]
+    }
+
+    // MARK: - Private
+
+    private let component: Component
+    private let providers: [PluginizedProcessedDependencyProvider]
+}

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyPropsSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyPropsSerializer.swift
@@ -1,0 +1,67 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+class DependencyPropsSerializer: Serializer {
+    
+    init(component: Component) {
+        self.component = component
+    }
+    
+    func serialize() -> String {
+        if component.isLeaf {
+            return """
+extension \(component.name): Registration {
+    public func registerItems() {
+\(serialize(component.dependency))
+    }
+}
+
+"""
+        } else {
+            return """
+extension \(component.name): Registration {
+    public func registerItems() {
+\(serialize(component.dependency))
+\(serialize(component.properties))
+    }
+}
+
+"""
+        }
+    }
+
+    // MARK: - Private
+
+    private func serialize(_ dependency: Dependency) -> String {
+        let dependencyName = dependency.name
+        return dependency.properties.map { property in
+            return "        keyPathToName[\\\(dependencyName).\(property.name)] = \"\(property.name)-\(property.type)\""
+        }.joined(separator: "\n")
+    }
+
+    private func serialize(_ properties: [Property]) -> String {
+        return properties.filter { property in
+            !property.isInternal
+        }.map { property in
+            return "        localTable[\"\(property.name)-\(property.type)\"] = { self.\(property.name) as Any }"
+        }.joined(separator: "\n")
+    }
+
+    private let component: Component
+}
+

--- a/Generator/Sources/NeedleFramework/Generating/Serializers/Pluginized/PluginExtensionDynamicContentSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/Pluginized/PluginExtensionDynamicContentSerializer.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A serializer that produces the class definitation source code for the
+/// plugin extension provider.
+class PluginExtensionDynamicContentSerializer: Serializer {
+
+    /// Initializer.
+    ///
+    /// - parameter component: The pluginized component for which is associated
+    ///   with this plugin extension
+    init(component: PluginizedComponent) {
+        self.component = component
+    }
+
+    /// Serialize the data model and produce the source code.
+    ///
+    /// - returns: The plugin extension class implemention source code.
+    func serialize() -> String {
+        let properties = serialize(properties: component.pluginExtension.properties)
+        
+        return """
+        /// \(component.data.name) plugin extension
+        extension \(component.data.name): ExtensionRegistration {
+            public func registerExtensionItems() {
+        \(properties)
+            }
+        }
+
+        """
+    }
+    
+    func serialize(properties: [Property]) -> String {
+        return properties.map { property in
+            return "        extensionToName[\\\(component.pluginExtension.name).\(property.name)] = \"\(property.name)-\(property.type)\""
+        }.joined(separator: "\n")
+    }
+
+    // MARK: - Private
+
+    private let component: PluginizedComponent
+}


### PR DESCRIPTION
- Code generated is guarded so current behavior is not affected
- Both paths are generated in the same file, the parsing of the `#if` should not slow things down
- Addresses https://github.com/uber/needle/issues/432