### PR TITLE
Add scopeWillDeinit lifecycle method to PluginizedComponent

### DIFF
--- a/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
+++ b/Sources/NeedleFoundation/Pluginized/PluginizedComponent.swift
@@ -146,6 +146,8 @@ open class PluginizedComponent<DependencyType, PluginExtensionType, NonCoreCompo
             case .inactive:
                 self.releasableNonCoreComponent?.scopeDidBecomeInactive()
             case .deinit:
+                self.scopeWillDeinit()
+                
                 // Only release the non-core component after the consumer, which should
                 // be the owner reference to the component is released. Cannot release
                 // the non-core component when the bound lifecyle is deactivated. The
@@ -156,6 +158,12 @@ open class PluginizedComponent<DependencyType, PluginExtensionType, NonCoreCompo
             }
         }
     }
+    
+    /// Indicates that the corresponding scope will deinit
+    ///
+    /// - note: This method is automatically invoked when the bound `PluginizedScopeLifecycleObservable`
+    /// enters its `deinit` state
+    open func scopeWillDeinit() {}
 
     // MARK: - Private
 

--- a/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
+++ b/Tests/NeedleFoundationTests/Pluginized/PluginizedComponentTests.swift
@@ -94,6 +94,27 @@ class PluginizedComponentTests: XCTestCase {
         XCTAssertNil(noncoreComponent)
         XCTAssertEqual(noncoreDeinitCallCount, 1)
     }
+    
+    func test_bindTo_verifyWillDeinit() {
+        let mockPluginizedComponent = MockPluginizedComponent()
+        let mockDisposable = MockObserverDisposable()
+        let mockLifecycle = MockPluginizedScopeLifecycleObervable(disposable: mockDisposable)
+        mockPluginizedComponent.bind(to: mockLifecycle)
+
+        XCTAssertEqual(mockPluginizedComponent.scopeWillDeinitCallCount, 0)
+
+        mockLifecycle.observer!(.active)
+
+        XCTAssertEqual(mockPluginizedComponent.scopeWillDeinitCallCount, 0)
+
+        mockLifecycle.observer!(.inactive)
+
+        XCTAssertEqual(mockPluginizedComponent.scopeWillDeinitCallCount, 0)
+
+        mockLifecycle.observer!(.deinit)
+
+        XCTAssertEqual(mockPluginizedComponent.scopeWillDeinitCallCount, 1)
+    }
 }
 
 class MockNonCoreComponent: NonCoreComponent<EmptyDependency> {
@@ -122,8 +143,14 @@ class EmptyPluginExtensionsProvider: EmptyPluginExtensions {}
 
 class MockPluginizedComponent: PluginizedComponent<EmptyDependency, EmptyPluginExtensions, MockNonCoreComponent> {
 
+    var scopeWillDeinitCallCount = 0
+    
     init() {
         super.init(parent: BootstrapComponent())
+    }
+    
+    override func scopeWillDeinit() {
+        scopeWillDeinitCallCount += 1
     }
 }
 


### PR DESCRIPTION
Adds `scopeWillDeinit` lifecycle method to `PluginizedComponent`.
`scopeWillDeinit` can be used by subclasses of `PluginizedComponent` to perform cleanup and other actions they may require when their associated scope is going to `deinit`.