### PR TITLE
Add UberPluginizedComponent to Needle Generator

### DIFF
--- a/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedConstants.swift
+++ b/Generator/Sources/NeedleFramework/Parsing/Pluginized/PluginizedConstants.swift
@@ -20,5 +20,8 @@ let pluginExtensionProtocolName = "PluginExtension"
 /// The name of the class that all PluginizedComponent classes inherit from
 let pluginizedComponentClassName = "PluginizedComponent"
 
+/// The name of the class that all Uber PluginizedComponent classes inherit from
+let uberPluginizedComponentClassName = "UberPluginizedComponent"
+
 /// The name of the class that all NonCoreComponent classes inherit from
 let nonCoreComponentClassName = "NonCoreComponent"

--- a/Generator/Sources/NeedleFramework/Utilities/SwiftSyntaxExtensions.swift
+++ b/Generator/Sources/NeedleFramework/Utilities/SwiftSyntaxExtensions.swift
@@ -91,7 +91,9 @@ extension ClassDeclSyntax: EntityNode {
     }
 
     var isPluginizedComponent: Bool {
-        inherits(from: pluginizedComponentClassName) && inheritanceHasGenericArgument
+        ((inherits(from: pluginizedComponentClassName)) || inherits(from: uberPluginizedComponentClassName))
+        && typeName != uberPluginizedComponentClassName
+        && inheritanceHasGenericArgument
     }
 
     var isNonCoreComponent: Bool {

--- a/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
+++ b/Generator/Tests/NeedleFrameworkTests/Generating/Pluginized/PluginizedDependencyGraphExporterTests.swift
@@ -49,7 +49,7 @@ class PluginizedDependencyGraphExporterTests: AbstractPluginizedGeneratorTests {
         XCTAssertTrue(generated.contains("import UIKit"))
         XCTAssertTrue(generated.contains("import ScoreSheet"))
         XCTAssertTrue(generated.contains("import TicTacToeIntegrations"))
-        XCTAssertTrue(generated.contains("private let needleDependenciesHash : String? = \"f7e65514498ad4f99ae8eb589dd36bbc\""))
+        XCTAssertTrue(generated.contains("private let needleDependenciesHash : String? = \"4b585865bab35437b0cbc60e9d74b1b1\""))
         XCTAssertTrue(generated.contains("// MARK: - Registration"))
         XCTAssertTrue(generated.contains("""
     registerProviderFactory(\"^->RootComponent->LoggedOutComponent\", factory1434ff4463106e5c4f1bb3a8f24c1d289f2c0f2e)

--- a/Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
+++ b/Sample/Pluginized/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		413909A620A4EA7300A26FF5 /* GameComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413909A520A4EA7300A26FF5 /* GameComponent.swift */; };
 		41869A49212E288C0076C04B /* PluginizedScopeLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41869A48212E288C0076C04B /* PluginizedScopeLifecycle.swift */; };
 		41869A4B212E294F0076C04B /* ObservableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41869A4A212E294F0076C04B /* ObservableViewController.swift */; };
+		7E9E1FB42950D2B3009EF31E /* UberPluginizedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9E1FB32950D2B3009EF31E /* UberPluginizedComponent.swift */; };
 		D350108C25B0C576000953FA /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = D350108B25B0C576000953FA /* SnapKit */; };
 		D350109325B0C5E8000953FA /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D350109225B0C5E8000953FA /* RxSwift */; };
 		D350109525B0C5E8000953FA /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = D350109425B0C5E8000953FA /* RxCocoa */; };
@@ -180,6 +181,7 @@
 		41869A48212E288C0076C04B /* PluginizedScopeLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginizedScopeLifecycle.swift; sourceTree = "<group>"; };
 		41869A4A212E294F0076C04B /* ObservableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableViewController.swift; sourceTree = "<group>"; };
 		41F6882821F802A000AA3CCA /* NeedleFoundation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NeedleFoundation.xcodeproj; path = ../../../NeedleFoundation.xcodeproj; sourceTree = "<group>"; };
+		7E9E1FB32950D2B3009EF31E /* UberPluginizedComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UberPluginizedComponent.swift; sourceTree = "<group>"; };
 		F7DA7ADF20A275DA0037FF17 /* ScoreSheetComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreSheetComponent.swift; sourceTree = "<group>"; };
 		F7DA7AE120A275EF0037FF17 /* ScoreSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreSheetViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -303,6 +305,7 @@
 				4139096220A0F2BD00A26FF5 /* Info.plist */,
 				41869A48212E288C0076C04B /* PluginizedScopeLifecycle.swift */,
 				41869A4A212E294F0076C04B /* ObservableViewController.swift */,
+				7E9E1FB32950D2B3009EF31E /* UberPluginizedComponent.swift */,
 			);
 			path = TicTacToeCore;
 			sourceTree = "<group>";
@@ -696,6 +699,7 @@
 				4139099920A2483300A26FF5 /* LoggedInComponent.swift in Sources */,
 				413909A620A4EA7300A26FF5 /* GameComponent.swift in Sources */,
 				4139097D20A1174700A26FF5 /* NeedleGenerated.swift in Sources */,
+				7E9E1FB42950D2B3009EF31E /* UberPluginizedComponent.swift in Sources */,
 				4139099720A2481700A26FF5 /* LoggedInViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/Game/GameComponent.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/Game/GameComponent.swift
@@ -28,7 +28,7 @@ protocol GamePluginExtension: PluginExtension {
     var scoreSheetBuilder: ScoreSheetBuilder { get }
 }
 
-class GameComponent: PluginizedComponent<GameDependency, GamePluginExtension, GameNonCoreComponent>, GameBuilder {
+class GameComponent: UberPluginizedComponent<GameDependency, GamePluginExtension, GameNonCoreComponent>, GameBuilder {
 
     var gameViewController: UIViewController {
         return shared {

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/NeedleGenerated.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/NeedleGenerated.swift
@@ -21,7 +21,7 @@ import TicTacToeIntegrations
 import UIKit
 
 // swiftlint:disable unused_declaration
-private let needleDependenciesHash : String? = "f7e65514498ad4f99ae8eb589dd36bbc"
+private let needleDependenciesHash : String? = "4b585865bab35437b0cbc60e9d74b1b1"
 
 // MARK: - Traversal Helpers
 

--- a/Sample/Pluginized/TicTacToe/TicTacToeCore/UberPluginizedComponent.swift
+++ b/Sample/Pluginized/TicTacToe/TicTacToeCore/UberPluginizedComponent.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import NeedleFoundation
+
+// PluginizedComponent subclass for adding additional behaviour to PluginizedComponent
+// Exists in this repo for Needle Generator testing purposes
+open class UberPluginizedComponent<DependencyType, PluginExtensionType, NonCoreComponent: NonCoreScope>: PluginizedComponent<DependencyType, PluginExtensionType, NonCoreComponent> {}


### PR DESCRIPTION
Adds a new class `UberPluginizedComponent` to Needle Generator.
Generator changes are tested through tests subclassing `AbstractPluginizedGeneratorTests`,
`UberPluginizedComponent` was added to Pluginized/TicTacToe as it is the target source for `AbstractPluginizedGeneratorTests`.

Rebuilt needle executable using  `make archive_generator` command.