### PR TITLE
Break some cycles in the new codepath

### DIFF
--- a/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyPropsSerializer.swift
+++ b/Generator/Sources/NeedleFramework/Generating/Serializers/DependencyPropsSerializer.swift
@@ -58,7 +58,7 @@ extension \(component.name): Registration {
         return properties.filter { property in
             !property.isInternal
         }.map { property in
-            return "        localTable[\"\(property.name)-\(property.type)\"] = { self.\(property.name) as Any }"
+            return "        localTable[\"\(property.name)-\(property.type)\"] = { [unowned self] in self.\(property.name) as Any }"
         }.joined(separator: "\n")
     }
 

--- a/Sources/NeedleFoundation/Component.swift
+++ b/Sources/NeedleFoundation/Component.swift
@@ -47,7 +47,7 @@ public protocol Scope: AnyObject {
 public class DependencyProvider<DependencyType> {
     
     /// The parent component of this provider.
-    let component: Component<DependencyType>
+    weak var component: Component<DependencyType>?
     let nonCore: Bool
 
     init(component: Component<DependencyType>, nonCore: Bool) {
@@ -56,7 +56,7 @@ public class DependencyProvider<DependencyType> {
     }
 
     public func find<T>(property: String) -> T {
-        return component.parent.find(property: property, skipThisLevel: nonCore)
+        return component!.parent.find(property: property, skipThisLevel: nonCore)
     }
 
     public subscript<T>(dynamicMember keyPath: KeyPath<DependencyType, T>) -> T {
@@ -64,7 +64,7 @@ public class DependencyProvider<DependencyType> {
     }
     
     public func lookup<T>(keyPath: KeyPath<DependencyType, T>) -> T {
-        guard let propertyName = component.keyPathToName[keyPath] else {
+        guard let propertyName = component!.keyPathToName[keyPath] else {
              fatalError("Cound not find \(keyPath) in lookup table")
         }
         return find(property: propertyName)


### PR DESCRIPTION
- Pointer from dependency provider back to component needs to be weak
- Closures should use unonwed self to avoid cycle

While both the force-unwrap and unonwned seem very unsafe, we are relying on the fact that the lifetimes of these things are expected to be perfectly in sync.