### PR TITLE
Add actions file to publish automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish to formula & CocoaPods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: make publish


### PR DESCRIPTION
- Add actions file to publish automatically so that anyone won't forget to publish. (Today's latest version we can install from Podspec is [0.17.2](https://cocoapods.org/pods/NeedleFoundation) although latest release version is [0.22.0](https://github.com/uber/needle/blob/d3eaf696ad2e4c3e25618cfa3643402fdd237f7a/NeedleFoundation.podspec#L3))

※ To make this actions work, I want owner of this repository to set secrets(COCOAPODS_TRUNK_TOKEN) like below.
![スクリーンショット 2023-01-10 22 44 06](https://user-images.githubusercontent.com/41050625/211567341-73dd44aa-6f8e-4ed8-9b3c-66e6888165ce.png)
