### PR TITLE
Add Generator as a subspec

### DIFF
--- a/NeedleFoundation.podspec
+++ b/NeedleFoundation.podspec
@@ -12,4 +12,8 @@ Pod::Spec.new do |s|
   s.source_files     = 'Sources/**/*.swift'
   s.ios.deployment_target = '9.0'
   s.swift_versions   = ['5.2', '5.3', '5.4', '5.5', '5.6']
+
+  s.subspec 'Generator' do |ss|
+    ss.source_files = 'Generator/*'
+  end
 end


### PR DESCRIPTION
- Add a subspec to be able to use generator under a `/Generator/*` directory.

Originally, we couldn't use the generator when we download through Pod cuz source files is specified like below.
https://github.com/uber/needle/blob/d3eaf696ad2e4c3e25618cfa3643402fdd237f7a/NeedleFoundation.podspec#L12

That's why, I wanna make it possible to use the generator through Pod by adding a subspec.
And I suppose usage is like this. `pod 'NeedleFoundation/Generator'`

And I think adding another podspec file is also fine besides of NeedleFoundation.podspec. But in terms of a maintenance cost, I took the one of adding a subspec.