### PR TITLE
Introduce Weak Singleton. Provide dependencies based on arguments

### DIFF
--- a/NeedleFoundation.xcodeproj/project.pbxproj
+++ b/NeedleFoundation.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		3D35CB7C298A7FE800A374EC /* Nothing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D35CB75298A7FE800A374EC /* Nothing.swift */; };
+		3D35CB80298A7FE800A374EC /* AssemblyStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D35CB7B298A7FE800A374EC /* AssemblyStorage.swift */; };
 		OBJ_42 /* Bootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Bootstrap.swift */; };
 		OBJ_43 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Component.swift */; };
 		OBJ_44 /* DependencyProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* DependencyProviderRegistry.swift */; };
@@ -78,6 +80,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3D35CB75298A7FE800A374EC /* Nothing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nothing.swift; sourceTree = "<group>"; };
+		3D35CB7B298A7FE800A374EC /* AssemblyStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssemblyStorage.swift; sourceTree = "<group>"; };
 		"NeedleFoundation::NeedleFoundation::Product" /* NeedleFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NeedleFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"NeedleFoundation::NeedleFoundationTest::Product" /* NeedleFoundationTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = NeedleFoundationTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"NeedleFoundation::NeedleFoundationTestTests::Product" /* NeedleFoundationTestTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = NeedleFoundationTestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,6 +138,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7D1A478F298E7859004832D4 /* Misc */ = {
+			isa = PBXGroup;
+			children = (
+				3D35CB75298A7FE800A374EC /* Nothing.swift */,
+				3D35CB7B298A7FE800A374EC /* AssemblyStorage.swift */,
+			);
+			path = Misc;
+			sourceTree = "<group>";
+		};
 		OBJ_11 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
@@ -243,6 +256,7 @@
 		OBJ_8 /* NeedleFoundation */ = {
 			isa = PBXGroup;
 			children = (
+				7D1A478F298E7859004832D4 /* Misc */,
 				OBJ_9 /* Bootstrap.swift */,
 				OBJ_10 /* Component.swift */,
 				OBJ_11 /* Internal */,
@@ -378,7 +392,9 @@
 				OBJ_45 /* PluginExtensionProviderRegistry.swift in Sources */,
 				OBJ_46 /* NonCoreComponent.swift in Sources */,
 				OBJ_47 /* PluginizedComponent.swift in Sources */,
+				3D35CB80298A7FE800A374EC /* AssemblyStorage.swift in Sources */,
 				OBJ_48 /* PluginizedScopeLifecycle.swift in Sources */,
+				3D35CB7C298A7FE800A374EC /* Nothing.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -489,6 +505,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -538,6 +555,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NeedleFoundation.xcodeproj/NeedleFoundation_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/Sources/NeedleFoundation/Misc/AssemblyStorage.swift
+++ b/Sources/NeedleFoundation/Misc/AssemblyStorage.swift
@@ -1,0 +1,89 @@
+//
+//  AssemblyStorage.swift
+//  NeedleFoundation
+//
+//  Created by Mikhail Maslo on 04.02.23.
+//
+
+final class AssemblyStorage {
+    final class WeakBox {
+        weak var object: AnyObject?
+
+        init<Object: AnyObject>(object: Object) {
+            self.object = object
+        }
+    }
+
+    private lazy var strongObjects: [Key: Any] = [:]
+    private lazy var weakObjects: [Key: WeakBox] = [:]
+
+    init() {}
+
+    func shared<Args: Hashable, Object>(function: StaticString, args: Args, factory: () -> Object) -> Object {
+        let key = Key(function: function, args: args)
+        if let object = strongObjects[key] {
+            return object as! Object
+        }
+
+        let object = factory()
+        strongObjects[key] = object
+        return object
+    }
+
+    func weakShared<Args: Hashable, Object: AnyObject>(function: StaticString, args: Args, factory: () -> Object) -> Object {
+        let key = Key(function: function, args: args)
+        if let object = weakObjects[key]?.object {
+            return object as! Object
+        }
+
+        let object = factory()
+        weakObjects[key] = WeakBox(object: object)
+        return object
+    }
+}
+
+final class Key: Hashable {
+    // MARK: - Private properties
+
+    private let function: StaticString
+    private let args: AnyHashable
+
+    // MARK: - Init
+
+    init<Args>(function: StaticString, args: Args) where Args: Hashable {
+        self.function = function
+        self.args = args
+    }
+
+    // MARK: - Hashable
+
+    static func == (lhs: Key, rhs: Key) -> Bool {
+        isSameFunction(function1: lhs.function, function2: rhs.function) && lhs.args == rhs.args
+    }
+
+    func hash(into hasher: inout Hasher) {
+        var hasher = Hasher()
+
+        if function.hasPointerRepresentation {
+            hasher.combine(function.utf8Start)
+        } else {
+            hasher.combine(function.unicodeScalar)
+        }
+
+        hasher.combine(args)
+    }
+
+    // MARK: - Private methods
+
+    private static func isSameFunction(function1: StaticString, function2: StaticString) -> Bool {
+        guard function1.hasPointerRepresentation == function2.hasPointerRepresentation else {
+            return false
+        }
+
+        if function1.hasPointerRepresentation {
+            return function1.utf8Start == function2.utf8Start
+        } else {
+            return function1.unicodeScalar == function2.unicodeScalar
+        }
+    }
+}

--- a/Sources/NeedleFoundation/Misc/Nothing.swift
+++ b/Sources/NeedleFoundation/Misc/Nothing.swift
@@ -1,0 +1,22 @@
+//
+//  AssemblyStorage.swift
+//  NeedleFoundation
+//
+//  Created by Mikhail Maslo on 04.02.23.
+//
+
+struct Nothing {
+    public init() {}
+}
+
+extension Nothing: Equatable {
+    public static func == (lhs: Nothing, rhs: Nothing) -> Bool {
+        true
+    }
+}
+
+extension Nothing: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        // Do nothing
+    }
+}

--- a/Tests/NeedleFoundationTests/ComponentTests.swift
+++ b/Tests/NeedleFoundationTests/ComponentTests.swift
@@ -40,6 +40,49 @@ class ComponentTests: XCTestCase {
         let component = TestComponent()
         XCTAssert(component.optionalShare === component.expectedOptionalShare)
     }
+
+    func test_sharedWithArgs_verifySingleInstance() {
+        let component = TestComponent()
+        let args = "args"
+        XCTAssert(component.share(args: args) === component.share(args: args), "Should have returned same shared object")
+    }
+
+    func test_sharedWithArgs_verifyDifferentInstancePerArgs() {
+        let component = TestComponent()
+        let args1 = "args1"
+        let args2 = "args2"
+        XCTAssert(component.share(args: args1) !== component.share(args: args2), "Should have returned different shared object")
+    }
+
+    func test_weakShared_verifySingleInstance() {
+        let component = TestComponent()
+        let weakShare1 = component.weakShare
+        let weakShare2 = component.weakShare
+        XCTAssert(weakShare1 === weakShare2, "Should have returned same shared object")
+    }
+
+    func test_weakReferenceOfWeakShared_deallocated() {
+        let component = TestComponent()
+        weak var weakShare = component.weakShare
+        XCTAssert(weakShare == nil, "Should have been deallocated without a strong reference")
+    }
+
+    func test_weakSharedWithSameArgs_verifySingleInstance() {
+        let component = TestComponent()
+        let args = "args"
+        let weakShare1 = component.weakShare(args: args)
+        let weakShare2 = component.weakShare(args: args)
+        XCTAssert(weakShare1 === weakShare2, "Should have returned same shared object")
+    }
+
+    func test_weakSharedWithDifferentArgs_verifyDifferentInstance() {
+        let component = TestComponent()
+        let args1 = "args1"
+        let args2 = "args2"
+        let weakShare1 = component.weakShare(args: args1)
+        let weakShare2 = component.weakShare(args: args2)
+        XCTAssert(weakShare1 !== weakShare2, "Should have been different with different arguments")
+    }
 }
 
 class TestComponent: BootstrapComponent {
@@ -60,6 +103,18 @@ class TestComponent: BootstrapComponent {
 
     fileprivate var optionalShare: ClassProtocol? {
         return shared { self.expectedOptionalShare }
+    }
+
+    func share<Arg: Hashable>(args: Arg) -> NSObject {
+        return shared(args: args) { NSObject() }
+    }
+
+    var weakShare: NSObject {
+        return weakShared { NSObject() }
+    }
+
+    func weakShare<Arg: Hashable>(args: Arg) -> NSObject {
+        return weakShared(args: args) { NSObject() }
     }
 }
 


### PR DESCRIPTION
# Introduction of Weak Singleton

Needle has been providing users with singleton dependencies through its shared method, which is the most common use case for dependency injection. However, there are situations where weak singletons can be more appropriate.

For instance, when multiple objects require the same *new* dependency, using a weak singleton instead of a traditional singleton can be more efficient. In such a case dependency provided as a weak singleton can be safely destroyed when no one needs it and recreated again when it's used, as opposed to singleton which remains in memory and potentially retaining previous state.

# Introduction of arguments

There are cases, when it's convenient to create unique object per some unique feature. For example, you might need a separate object per object id or you might want to make unique data fetcher per endpoint, etc

With this change, it would be possible to create an object based on arguments. Arguments is an instance which should be `Hashable` for comparison. Providing different arguments for singleton will result in a new singleton per unique argument. The same logic applies to weak singletons.

Example:
```Swift
// ProductComponent

func productModel(productID: String) -> ProductModel {
  return shared(args: productID) { ... }
}

let productModel1 = productComponent.productModel(productID: productID1) // is unique instance
let productModel2 = productComponent.productModel(productID: productID2) // is unique instance
let productModel3 = productComponent.productModel(productID: productID1) // is the same instance as productModel1 because arguments is the same - productID1
```

# Replace `String` with `StaticString` in `#function`

In the current needle implementation `__function` parameter used as a key for dependency which is great because it's unique in the scope of the component and it's efficient.

Since arguments is introduced and `__function` is not the only key to dependency anymore, we can consider using `StaticString` instead. `#function` expression is replaced with the actual value at a compile time, so they are basically `StaticString`. As an adventage, `StaticString` can be compared by reference which is faster than string comparison

It's not a required change but seems to be appropriate in the context of arguments introduction

# Side notes

- I'm not sure which copyright should be used in new files, so I've just left the default ones. Let me know, if it needs to be changed.
- I've added tests for `weakSingleton` & `args` in `Component` but not for `AssemblyStorage`. It seems that `Component` tests should be enough to cover `AssemblyStorage` usage