### PR TITLE
Add LoggedInDependency protocol in sample projects.

### DIFF
--- a/Sample/MVC/TicTacToe/Sources/LoggedIn/LoggedInComponent.swift
+++ b/Sample/MVC/TicTacToe/Sources/LoggedIn/LoggedInComponent.swift
@@ -17,7 +17,11 @@
 import NeedleFoundation
 import UIKit
 
-class LoggedInComponent: Component<EmptyDependency>, LoggedInBuilder {
+protocol LoggedInDependency: Dependency {
+
+}
+
+class LoggedInComponent: Component<LoggedInDependency>, LoggedInBuilder {
 
     var scoreStream: ScoreStream {
         return mutableScoreStream

--- a/Sample/SwiftUI-MVVM/TicTacToe/Sources/LoggedIn/LoggedInComponent.swift
+++ b/Sample/SwiftUI-MVVM/TicTacToe/Sources/LoggedIn/LoggedInComponent.swift
@@ -17,7 +17,11 @@
 import NeedleFoundation
 import SwiftUI
 
-class LoggedInComponent: Component<EmptyDependency>, LoggedInBuilder {
+protocol LoggedInDependency: Dependency {
+
+}
+
+class LoggedInComponent: Component<LoggedInDependency>, LoggedInBuilder {
 
     var scoreStream: ScoreStream {
         return mutableScoreStream


### PR DESCRIPTION
I think using EmptyDependency in the tutorial seems incorrect and could potentially confuse beginners.

In the EmptyDependency's comments, it is mentioned that EmptyDependency is a protocol for the Root Component and used in the bootstrap, but in the tutorial, it is being used in LoggedInComponent.

Additionally, I think using an empty LoggedInDependency instead of EmptyDependency would be more scalable and flexible for future modifications.