### PR TITLE
Remove unused additional nil coalescing

### DIFF
--- a/Sources/NeedleFoundation/Component.swift
+++ b/Sources/NeedleFoundation/Component.swift
@@ -139,12 +139,7 @@ open class Component<DependencyType>: Scope {
             sharedInstanceLock.unlock()
         }
 
-        // Additional nil coalescing is needed to mitigate a Swift bug appearing
-        // in Xcode 10. see https://bugs.swift.org/browse/SR-8704. Without this
-        // measure, calling `shared` from a function that returns an optional type
-        // will always pass the check below and return nil if the instance is not
-        // initialized.
-        if let instance = (sharedInstances[__function] as? T?) ?? nil {
+        if let instance = (sharedInstances[__function] as? T) {
             return instance
         }
         let instance = factory()
@@ -248,12 +243,7 @@ open class Component<DependencyType>: Scope {
             sharedInstanceLock.unlock()
         }
 
-        // Additional nil coalescing is needed to mitigate a Swift bug appearing
-        // in Xcode 10. see https://bugs.swift.org/browse/SR-8704. Without this
-        // measure, calling `shared` from a function that returns an optional type
-        // will always pass the check below and return nil if the instance is not
-        // initialized.
-        if let instance = (sharedInstances[__function] as? T?) ?? nil {
+        if let instance = (sharedInstances[__function] as? T) {
             return instance
         }
         let instance = factory()


### PR DESCRIPTION
Resolved [SR-8704](https://bugs.swift.org/browse/SR-8704) issue by [19217](https://github.com/apple/swift/pull/19217)

We can remove unused nil coalescing and comments.