### PR TITLE
Introduces a per-injection-point lock to avoid deadlocks

### DIFF
--- a/Sources/NeedleFoundation/Component.swift
+++ b/Sources/NeedleFoundation/Component.swift
@@ -72,6 +72,8 @@ public class DependencyProvider<DependencyType> {
 
 }
 
+#endif
+
 /// The base implementation of a dependency injection component. A subclass
 /// defines a unique scope within the dependency injection tree, that
 /// contains a set of properties it provides to units of its scope as well
@@ -96,23 +98,17 @@ open class Component<DependencyType>: Scope {
     ///
     /// - note: Accessing this property is not thread-safe. It should only be
     /// accessed on the same thread as the one that instantiated this component.
+#if NEEDLE_DYNAMIC
     public private(set) var dependency: DependencyProvider<DependencyType>!
-
-    /// Initializer.
-    ///
-    /// - parameter parent: The parent component of this component.
-    public init(parent: Scope) {
-        self.parent = parent
-        if let canRegister = self as? Registration {
-            canRegister.registerItems()
-        }
-        dependency = DependencyProvider(component: self, nonCore: false)
-    }
+#else
+    public private(set) var dependency: DependencyType!
+#endif
     
     /// Initializer.
     ///
     /// - parameter parent: The parent component of this component.
-    public init(parent: Scope, nonCore: Bool) {
+#if NEEDLE_DYNAMIC
+    public init(parent: Scope, nonCore: Bool = false) {
         self.parent = parent
         
         if let canRegister = self as? Registration {
@@ -120,6 +116,12 @@ open class Component<DependencyType>: Scope {
         }
         dependency = DependencyProvider(component: self, nonCore: nonCore)
     }
+#else
+    public init(parent: Scope) {
+        self.parent = parent
+        dependency = createDependencyProvider()
+    }
+#endif
     
     /// Share the enclosed object as a singleton at this scope. This allows
     /// this scope as well as all child scopes to share a single instance of
@@ -152,6 +154,8 @@ open class Component<DependencyType>: Scope {
 
         return instance
     }
+
+#if NEEDLE_DYNAMIC
 
     public func find<T>(property: String, skipThisLevel: Bool) -> T {
         guard let itemCloure = localTable[property] else {
@@ -170,102 +174,14 @@ open class Component<DependencyType>: Scope {
     public var localTable = [String:()->Any]()
     public var keyPathToName = [PartialKeyPath<DependencyType>:String]()
     
-    // MARK: - Private
-
-    private let sharedInstanceLock = NSRecursiveLock()
-    private var sharedInstances = [String: Any]()
-    private lazy var name: String = {
-        let fullyQualifiedSelfName = String(describing: self)
-        let parts = fullyQualifiedSelfName.components(separatedBy: ".")
-        return parts.last ?? fullyQualifiedSelfName
-    }()
-
-    // TODO: Replace this with an `open` method, once Swift supports extension
-    // overriding methods.
-    private func createDependencyProvider() -> DependencyType {
-        let provider = __DependencyProviderRegistry.instance.dependencyProvider(for: self)
-        if let dependency = provider as? DependencyType {
-            return dependency
-        } else {
-            // This case should never occur with properly generated Needle code.
-            // Needle's official generator should guarantee the correctness.
-            fatalError("Dependency provider factory for \(self) returned incorrect type. Should be of type \(String(describing: DependencyType.self)). Actual type is \(String(describing: dependency))")
-        }
-    }
-}
-
 #else
-
-/// The base implementation of a dependency injection component. A subclass
-/// defines a unique scope within the dependency injection tree, that
-/// contains a set of properties it provides to units of its scope as well
-/// as child scopes. A component instantiates child components that define
-/// child scopes.
-@dynamicMemberLookup
-open class Component<DependencyType>: Scope {
-
-    /// The parent of this component.
-    public let parent: Scope
-
-    /// The path to reach this scope on the dependency graph.
-    // Use `lazy var` to avoid computing the path repeatedly. Internally,
-    // this is always accessed with the `__DependencyProviderRegistry`'s lock
-    // acquired.
-    public lazy var path: [String] = {
-        let name = self.name
-        return parent.path + ["\(name)"]
-    }()
-
-    /// The dependency of this component.
-    ///
-    /// - note: Accessing this property is not thread-safe. It should only be
-    /// accessed on the same thread as the one that instantiated this component.
-    public private(set) var dependency: DependencyType!
-
-    /// Initializer.
-    ///
-    /// - parameter parent: The parent component of this component.
-    public init(parent: Scope) {
-        self.parent = parent
-        dependency = createDependencyProvider()
-    }
-
-    /// Share the enclosed object as a singleton at this scope. This allows
-    /// this scope as well as all child scopes to share a single instance of
-    /// the object, for as long as this component lives.
-    ///
-    /// - note: Shared dependency's constructor should avoid switching threads
-    /// as it may cause a deadlock.
-    ///
-    /// - parameter factory: The closure to construct the dependency object.
-    /// - returns: The dependency object instance.
-    public final func shared<T>(__function: String = #function, _ factory: () -> T) -> T {
-        // Use function name as the key, since this is unique per component
-        // class. At the same time, this is also 150 times faster than
-        // interpolating the type to convert to string, `"\(T.self)"`.
-        sharedInstanceLock.lock()
-        defer {
-            sharedInstanceLock.unlock()
-        }
-
-        // Additional nil coalescing is needed to mitigate a Swift bug appearing
-        // in Xcode 10. see https://bugs.swift.org/browse/SR-8704. Without this
-        // measure, calling `shared` from a function that returns an optional type
-        // will always pass the check below and return nil if the instance is not
-        // initialized.
-        if let instance = (sharedInstances[__function] as? T?) ?? nil {
-            return instance
-        }
-        let instance = factory()
-        sharedInstances[__function] = instance
-
-        return instance
-    }
 
     public subscript<T>(dynamicMember keyPath: KeyPath<DependencyType, T>) -> T {
         return dependency[keyPath: keyPath]
     }
-
+    
+#endif
+    
     // MARK: - Private
 
     private let sharedInstanceLock = NSRecursiveLock()
@@ -289,5 +205,3 @@ open class Component<DependencyType>: Scope {
         }
     }
 }
-
-#endif

--- a/Sources/NeedleFoundation/Component.swift
+++ b/Sources/NeedleFoundation/Component.swift
@@ -133,12 +133,11 @@ open class Component<DependencyType>: Scope {
     /// - parameter factory: The closure to construct the dependency object.
     /// - returns: The dependency object instance.
     public final func shared<T>(__function: String = #function, _ factory: () -> T) -> T {
-        // Use function name as the key, since this is unique per component
-        // class. At the same time, this is also 150 times faster than
-        // interpolating the type to convert to string, `"\(T.self)"`.
-        sharedInstanceLock.lock()
+        let provider = resolve(__function)
+        
+        provider.lock.lock()
         defer {
-            sharedInstanceLock.unlock()
+            provider.lock.unlock()
         }
 
         // Additional nil coalescing is needed to mitigate a Swift bug appearing
@@ -146,13 +145,26 @@ open class Component<DependencyType>: Scope {
         // measure, calling `shared` from a function that returns an optional type
         // will always pass the check below and return nil if the instance is not
         // initialized.
-        if let instance = (sharedInstances[__function] as? T?) ?? nil {
+        if let instance = (provider.instance as? T?) ?? nil {
             return instance
         }
         let instance = factory()
-        sharedInstances[__function] = instance
-
+        provider.instance = instance
         return instance
+    }
+    
+    private func resolve(_ name: String) -> SingletonProvider {
+        sharedInstanceLock.lock()
+        defer {
+            sharedInstanceLock.unlock()
+        }
+        
+        if let provider = sharedInstances[name] {
+            return provider
+        }
+        let provider = SingletonProvider()
+        sharedInstances[name] = provider
+        return provider
     }
 
 #if NEEDLE_DYNAMIC
@@ -183,9 +195,15 @@ open class Component<DependencyType>: Scope {
 #endif
     
     // MARK: - Private
-
+    
+    private class SingletonProvider {
+        let lock = NSRecursiveLock()
+        var instance: Any?
+    }
+    
     private let sharedInstanceLock = NSRecursiveLock()
-    private var sharedInstances = [String: Any]()
+    private var sharedInstances = [String: SingletonProvider]()
+    
     private lazy var name: String = {
         let fullyQualifiedSelfName = String(describing: self)
         let parts = fullyQualifiedSelfName.components(separatedBy: ".")
@@ -204,4 +222,5 @@ open class Component<DependencyType>: Scope {
             fatalError("Dependency provider factory for \(self) returned incorrect type. Should be of type \(String(describing: DependencyType.self)). Actual type is \(String(describing: dependency))")
         }
     }
+    
 }


### PR DESCRIPTION
We are observing some deadlocks in our project, mostly caused by a complex injection hierarchy. After some research, we concluded some possible injection paths can lead into it:

For instance, given the follow `Component`s:
```mermaid
classDiagram
        Foundation <|-- Tracking
        Foundation <|-- Observability
        Foundation : +Logger logger
        Foundation : +Client httpClient
        Tracking : +TrackingService trackingService
        Observability : +ObservabilityService observabiltyService
```
If we initialize concurrently (in different threads) 2 classes that both require some injection from `Tracking` and `Observability`, but in different order, then we'll have a deadlock on both trying to acquire a lock on `Foundation`'s:
```mermaid
classDiagram
ServiceA : +TrackingService trackingService
ServiceA : +ObservabilityService observabiltyService
ServiceB : +ObservabilityService observabiltyService
ServiceB : +TrackingService trackingService
```

We are proposing to introduce a per-injection-point lock (but still retaining the main lock in the component to mutate the `sharedInstances` map) to avoid this situation.

> [!NOTE]
> This PR is based on #484, see here the real diff https://github.com/gmazzo/needle/compare/simplify-component...fix-deadlock

In our real case, `ServiceA` and `ServiceB` are `bootstrappingService` and `devicesProfilingManager`. This is the crash:
```
CrashReporter Key:  449ce4c905518c2d2ab7c029890391d997feb07a

App Hang: The app was terminated while unresponsive

Thread 0 - com.apple.main-thread - (TH_STATE_WAITING)
0  libsystem_kernel.dylib +0x1ca4  ___psynch_mutexwait
1  libsystem_pthread.dylib +0x1d64 __pthread_mutex_firstfit_lock_wait
2  libsystem_pthread.dylib +0x17ec __pthread_mutex_firstfit_lock_slow
3  Foundation +0x4048c             -[NSRecursiveLock lock]
4  Glovo +0x2e00d14                Component.shared<A>(__function:_:)
5  Glovo +0x1884548                FraudModule.devicesProfilingManager.getter
6  Glovo +0x18877a0                protocol witness for FraudModuleProtocol.devicesProfilingManager.getter in conformance FraudModule
7  Glovo +0x133e070                closure #1 in CustomerFoundationModule.bootstrappingService.getter
8  Glovo +0x2e0114c                Component.shared<A>(__function:_:)
9  Glovo +0x133dea0                CustomerFoundationModule.bootstrappingService.getter
10 Glovo +0x133ef68                protocol witness for CustomerFoundationModuleProtocol.bootstrappingService.getter in conformance CustomerFoundationModule
11 Glovo +0x1357e4                 closure #1 in AccountModule.launchViewControllerFactory.getter
12 Glovo +0x2e0114c                Component.shared<A>(__function:_:)
13 Glovo +0x135734                 AccountModule.launchViewControllerFactory.getter
14 Glovo +0x3e2b4                  protocol witness for AccountModuleProtocol.launchViewControllerFactory.getter in conformance AccountModule (<compiler-generated>)
......


Thread 19 - com.apple.root.user-initiated-qos - (TH_STATE_WAITING)
0  libsystem_kernel.dylib +0x1ca4  ___psynch_mutexwait
1  libsystem_pthread.dylib +0x1d64 __pthread_mutex_firstfit_lock_wait
2  libsystem_pthread.dylib +0x17ec __pthread_mutex_firstfit_lock_slow
3  Foundation +0x4048c             -[NSRecursiveLock lock]
4  Glovo +0x2e00d14                Component.shared<A>(__function:_:)
5  Glovo +0x1339670                CustomerFoundationModule.observabilityService.getter
6  Glovo +0x133ee28                protocol witness for CustomerFoundationModuleProtocol.observabilityService.getter in conformance CustomerFoundationModule
7  Glovo +0x1884804                closure #1 in FraudModule.devicesProfilingManager.getter
8  Glovo +0x2e0114c                Component.shared<A>(__function:_:)
9  Glovo +0x1884548                FraudModule.devicesProfilingManager.getter
10 Glovo +0x1eba0                  protocol witness for FraudModuleProtocol.devicesProfilingManager.getter in conformance FraudModule (<compiler-generated>)
11 Glovo +0x13c31d0                TransportHeadersFactory.includeSessionHeaders(_:)
12 Glovo +0x13c1248                TransportHeadersFactory.getRequestHeaders(for:)
13 Glovo +0x13c42d8                protocol witness for TransportHeadersFactoryProtocol.getRequestHeaders(for:) in conformance TransportHeadersFactory
14 Glovo +0x1373ffc                $s18CustomerFoundation13JSONTransportC14prepareRequest33_4A31403EA63FA50A6A144345B7AE17C1LL_12retryContext0B010URLRequestV0aB3API0cE0V_AA0c5RetryO0VSgtAJ17GlovoServiceErrorCYKF
15 Glovo +0x1370528                JSONTransport.execute<A>(_:callback:)
```