### PR TITLE
Add open fullyQualifiedName

### DIFF
--- a/Sources/NeedleFoundation/Component.swift
+++ b/Sources/NeedleFoundation/Component.swift
@@ -169,13 +169,21 @@ open class Component<DependencyType>: Scope {
 
     public var localTable = [String:()->Any]()
     public var keyPathToName = [PartialKeyPath<DependencyType>:String]()
-    
+
+    /// Fully qualified name of the Component, such as `"MyParentClass.EnumThatIsAComponent"`
+    ///
+    /// The default implementation uses `String(describing: self)`, which can be a bit slow. Override this
+    /// with a faster implementation (such as a hard-coded `String`) if you've identified slowness due to this property.
+    open var fullyQualifiedName: String {
+        String(describing: self)
+    }
+
     // MARK: - Private
 
     private let sharedInstanceLock = NSRecursiveLock()
     private var sharedInstances = [String: Any]()
     private lazy var name: String = {
-        let fullyQualifiedSelfName = String(describing: self)
+        let fullyQualifiedSelfName = fullyQualifiedName
         let parts = fullyQualifiedSelfName.components(separatedBy: ".")
         return parts.last ?? fullyQualifiedSelfName
     }()
@@ -266,12 +274,20 @@ open class Component<DependencyType>: Scope {
         return dependency[keyPath: keyPath]
     }
 
+    /// Fully qualified name of the Component, such as `"MyParentClass.EnumThatIsAComponent"`
+    ///
+    /// The default implementation uses `String(describing: self)`, which can be a bit slow. Override this
+    /// with a faster implementation (such as a hard-coded `String`) if you've identified slowness due to this property.
+    open var fullyQualifiedName: String {
+        String(describing: self)
+    }
+
     // MARK: - Private
 
     private let sharedInstanceLock = NSRecursiveLock()
     private var sharedInstances = [String: Any]()
     private lazy var name: String = {
-        let fullyQualifiedSelfName = String(describing: self)
+        let fullyQualifiedSelfName = fullyQualifiedName
         let parts = fullyQualifiedSelfName.components(separatedBy: ".")
         return parts.last ?? fullyQualifiedSelfName
     }()


### PR DESCRIPTION
I've seen a bit of app launch slowness because of this call to `String.init<A>(describing:)` on the order of 250ms.

This PR provides a hook for developers to provide their own compile-time implementation of `fullyQualifiedSelfName`, erasing the app-launch delays associated with `String.init<A>(describing:)`

### AI

This PR and its associated metadata was written without any AI assistance.