### PR TITLE
`Component.name` optimized: replace `String(describing:)` with `_typeName`

### DIFF
--- a/Sources/NeedleFoundation/Component.swift
+++ b/Sources/NeedleFoundation/Component.swift
@@ -174,11 +174,7 @@ open class Component<DependencyType>: Scope {
 
     private let sharedInstanceLock = NSRecursiveLock()
     private var sharedInstances = [String: Any]()
-    private lazy var name: String = {
-        let fullyQualifiedSelfName = String(describing: self)
-        let parts = fullyQualifiedSelfName.components(separatedBy: ".")
-        return parts.last ?? fullyQualifiedSelfName
-    }()
+    private lazy var name: String = _typeName(type(of: self), qualified: false)
 
     // TODO: Replace this with an `open` method, once Swift supports extension
     // overriding methods.
@@ -270,11 +266,7 @@ open class Component<DependencyType>: Scope {
 
     private let sharedInstanceLock = NSRecursiveLock()
     private var sharedInstances = [String: Any]()
-    private lazy var name: String = {
-        let fullyQualifiedSelfName = String(describing: self)
-        let parts = fullyQualifiedSelfName.components(separatedBy: ".")
-        return parts.last ?? fullyQualifiedSelfName
-    }()
+    private lazy var name: String = _typeName(type(of: self), qualified: false)
 
     // TODO: Replace this with an `open` method, once Swift supports extension
     // overriding methods.


### PR DESCRIPTION
Previously, `String(describing: self)` was used to get fully qualified name (including module name).

But using `String(describing: self)` to get type name is extremely ineffective (see https://github.com/uber/needle/pull/486 and https://github.com/swiftlang/swift/pull/77369). In the end `String(describing:)` calls `_typeName(:qualified:)` function. Also, if we pass `qualified: false`, we don't need to do any splitting work

Previous callstack when using `String(describing:)`:

- [String(describing:)](https://github.com/swiftlang/swift/blob/bd554ba524968bb4f10ec0016ce8adca85c268b6/stdlib/public/core/Mirror.swift#L584)
- [_print_unlocked](https://github.com/swiftlang/swift/blob/main/stdlib/public/core/OutputStream.swift#L447). Because Any.Type does not conform any of checked protocols.
- [_adHocPrint_unlocked](https://github.com/swiftlang/swift/blob/bd554ba524968bb4f10ec0016ce8adca85c268b6/stdlib/public/core/OutputStream.swift#L389)
- [_adHocPrint_unlocked.printTypeName](https://github.com/swiftlang/swift/blob/bd554ba524968bb4f10ec0016ce8adca85c268b6/stdlib/public/core/OutputStream.swift#L308) 